### PR TITLE
prefer target_compile_definitions over add_compile_definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,5 +132,8 @@ if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     target_compile_options(uvatlastool PRIVATE ${WarningsEXE})
 endif()
 
-# We use Windows 7 here
-add_compile_definitions(_UNICODE UNICODE _WIN32_WINNT=0x0601)
+if(MSVC)
+    # We use Windows 7 here
+    target_compile_definitions(${PROJECT_NAME} PRIVATE _UNICODE UNICODE _WIN32_WINNT=0x0601)
+    target_compile_definitions(uvatlastool PRIVATE _UNICODE UNICODE _WIN32_WINNT=0x0601)
+endif()


### PR DESCRIPTION
Generally, we prefer `target_compile_definitions` over `add_compile_definitions` because the macros are bound to a target instead of being global. Additionally, move the definitions inside the `if(MSVC)` block because the macros are windows specific.