### PR TITLE
make building UVAtlasTool optional in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,32 +88,40 @@ if(MSVC)
     string(REPLACE "/GR " "/GR- " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 endif()
 
-if(NOT EXISTS "${CMAKE_SOURCE_DIR}/../DirectXMesh/CMakeLists.txt")
-    message(FATAL_ERROR "uvatalastool requires DirectXMesh library from http://go.microsoft.com/fwlink/?LinkID=324981" )
-endif()
-if(NOT EXISTS "${CMAKE_SOURCE_DIR}/../DirectXTex/CMakeLists.txt")
-    message(FATAL_ERROR "uvatalastool requires DirectXTex library from http://go.microsoft.com/fwlink/?LinkId=248926" )
-endif()
+option(BUILD_TOOLS "Build UVAtlasTool" ON)
 
-add_subdirectory(${CMAKE_SOURCE_DIR}/../DirectXMesh ${CMAKE_BINARY_DIR}/bin/CMake/DirectXMesh)
-add_subdirectory(${CMAKE_SOURCE_DIR}/../DirectXTex ${CMAKE_BINARY_DIR}/bin/CMake/DirectXTex)
+if(BUILD_TOOLS)
+    if(NOT EXISTS "${CMAKE_SOURCE_DIR}/../DirectXMesh/CMakeLists.txt")
+        message(FATAL_ERROR "uvatalastool requires DirectXMesh library from http://go.microsoft.com/fwlink/?LinkID=324981" )
+    endif()
+    if(NOT EXISTS "${CMAKE_SOURCE_DIR}/../DirectXTex/CMakeLists.txt")
+        message(FATAL_ERROR "uvatalastool requires DirectXTex library from http://go.microsoft.com/fwlink/?LinkId=248926" )
+    endif()
 
-add_executable(uvatlastool
-    UVAtlasTool/UVAtlas.cpp
-    UVAtlasTool/Mesh.cpp
-    UVAtlasTool/Mesh.h
-    UVAtlasTool/MeshOBJ.cpp
-    UVAtlasTool/SDKMesh.h)
-target_link_libraries(uvatlastool ${PROJECT_NAME} DirectXMesh DirectXTex)
-target_include_directories(uvatlastool PRIVATE ../DirectXMesh/DirectXMesh ../DirectXMesh/Utilities ../DirectXTex/DirectXTex)
+    add_subdirectory(${CMAKE_SOURCE_DIR}/../DirectXMesh ${CMAKE_BINARY_DIR}/bin/CMake/DirectXMesh)
+    add_subdirectory(${CMAKE_SOURCE_DIR}/../DirectXTex ${CMAKE_BINARY_DIR}/bin/CMake/DirectXTex)
+
+    add_executable(uvatlastool
+        UVAtlasTool/UVAtlas.cpp
+        UVAtlasTool/Mesh.cpp
+        UVAtlasTool/Mesh.h
+        UVAtlasTool/MeshOBJ.cpp
+        UVAtlasTool/SDKMesh.h)
+    target_link_libraries(uvatlastool ${PROJECT_NAME} DirectXMesh DirectXTex)
+    target_include_directories(uvatlastool PRIVATE ../DirectXMesh/DirectXMesh ../DirectXMesh/Utilities ../DirectXTex/DirectXTex)
+endif()
 
 if(MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE /fp:fast)
-    target_compile_options(uvatlastool PRIVATE /fp:fast)
+    if(BUILD_TOOLS)
+        target_compile_options(uvatlastool PRIVATE /fp:fast)
+    endif()
 
     if (${CMAKE_SIZEOF_VOID_P} EQUAL "4")
         target_compile_options(${PROJECT_NAME} PRIVATE /arch:SSE2)
-        target_compile_options(uvatlastool PRIVATE /arch:SSE2)
+        if(BUILD_TOOLS)
+            target_compile_options(uvatlastool PRIVATE /arch:SSE2)
+        endif()
     endif()
 endif()
 
@@ -121,19 +129,26 @@ if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
     set(WarningsLib "-Wpedantic" "-Wextra")
     target_compile_options(${PROJECT_NAME} PRIVATE ${WarningsLib})
 
-    set(WarningsEXE ${WarningsLib} "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic" "-Wno-exit-time-destructors" "-Wno-switch" "-Wno-switch-enum" "-Wno-language-extension-token" "-Wno-missing-prototypes")
-    target_compile_options(uvatlastool PRIVATE ${WarningsEXE})
+    if(BUILD_TOOLS)
+        set(WarningsEXE ${WarningsLib} "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic" "-Wno-exit-time-destructors" "-Wno-switch" "-Wno-switch-enum" "-Wno-language-extension-token" "-Wno-missing-prototypes")
+        target_compile_options(uvatlastool PRIVATE ${WarningsEXE})
+    endif()
 endif()
+
 if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     target_compile_options(${PROJECT_NAME} PRIVATE /permissive- /JMC- /Zc:__cplusplus)
     target_compile_options(uvatlastool PRIVATE /permissive- /Zc:__cplusplus)
 
-    set(WarningsEXE "/wd4365" "/wd4710" "/wd4820" "/wd5039" "/wd5045")
-    target_compile_options(uvatlastool PRIVATE ${WarningsEXE})
+    if(BUILD_TOOLS)
+        set(WarningsEXE "/wd4365" "/wd4710" "/wd4820" "/wd5039" "/wd5045")
+        target_compile_options(uvatlastool PRIVATE ${WarningsEXE})
+    endif()
 endif()
 
 if(MSVC)
     # We use Windows 7 here
     target_compile_definitions(${PROJECT_NAME} PRIVATE _UNICODE UNICODE _WIN32_WINNT=0x0601)
-    target_compile_definitions(uvatlastool PRIVATE _UNICODE UNICODE _WIN32_WINNT=0x0601)
+    if(BUILD_TOOLS)
+        target_compile_definitions(uvatlastool PRIVATE _UNICODE UNICODE _WIN32_WINNT=0x0601)
+    endif()
 endif()


### PR DESCRIPTION
This PR makes building UVAtlasTool optional in CMake, and it's defaulted to on. If we want to turn it off, we can do `cmake -DBUILD_TOOLS=OFF ..` while configuring CMake. 