### PR TITLE
Free 20% speed-up with simple #pragma omp parallel for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ cmake_minimum_required (VERSION 3.11)
 
 project (UVAtlas LANGUAGES CXX)
 
+# #pragma omp is used to specify Directives and Clauses. If /openmp is not specified in a compilation, the compiler ignores OpenMP clauses and directives
+add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/openmp>)
+
 option(BUILD_TOOLS "Build UVAtlasTool" ON)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/UVAtlas/isochart/meshoptimizestretch.cpp
+++ b/UVAtlas/isochart/meshoptimizestretch.cpp
@@ -395,14 +395,17 @@ float CIsochartMesh::CalOptimalAvgL2SquaredStretch(
     bool bAllChartSatisfiedStretch = true;
     const CBaseMeshInfo& baseInfo = chartList[0]->m_baseInfo;
     float fSumSqrtEiiaii = 0;
-    for (size_t ii=0; ii<chartList.size(); ii++)
+#pragma omp parallel for
+    for (int ii = 0; ii < chartList.size(); ii++)
     {
         float fEii = chartList[ii]->m_fParamStretchL2;
         float faii = chartList[ii]->m_fChart2DArea;
-        bAllChartSatisfiedStretch = 
+        bAllChartSatisfiedStretch =
             (bAllChartSatisfiedStretch && (fEii == faii));
 
-        fSumSqrtEiiaii += IsochartSqrtf(fEii * faii);
+        auto temp = IsochartSqrtf(fEii * faii); // For better profiling
+#pragma atomic
+        fSumSqrtEiiaii += temp;
     }
 
     if (bAllChartSatisfiedStretch)


### PR DESCRIPTION
Gives a 20% speed up in a machine with 12 cores, for "free", since if the compiler doesn't accept the /openmp flag it should ignore the changes suggested here and proceed as normal single-threaded