### PR TITLE
Code review for standard library header usage

### DIFF
--- a/UVAtlas/inc/UVAtlas.h
+++ b/UVAtlas/inc/UVAtlas.h
@@ -9,8 +9,6 @@
 
 #pragma once
 
-#include <cstdint>
-
 #if defined(_XBOX_ONE) && defined(_TITLE)
 #include <d3d11_x.h>
 #else
@@ -18,12 +16,15 @@
 #include <dxgiformat.h>
 #endif
 
-#include <DirectXMath.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <vector>
 
+#include <DirectXMath.h>
+
 #define UVATLAS_VERSION 181
+
 
 namespace DirectX
 {
@@ -94,7 +95,7 @@ namespace DirectX
     //               integrated metric tensor for that face. This lets you control
     //               the way this triangle may be stretched in the atlas. The IMT
     //               passed in will be 3 floats (a,b,c) and specify a symmetric
-    //               matrix (a b) that, given a vector (s,t), specifies the 
+    //               matrix (a b) that, given a vector (s,t), specifies the
     //                      (b c)
     //               distance between a vector v1 and a vector v2 = v1 + (s,t) as
     //               sqrt((s, t) * M * (s, t)^T).

--- a/UVAtlas/pch.h
+++ b/UVAtlas/pch.h
@@ -78,6 +78,7 @@
 #include <cstring>
 #include <functional>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <queue>
 

--- a/UVAtlas/pch.h
+++ b/UVAtlas/pch.h
@@ -65,21 +65,19 @@
 #include <Windows.h>
 #include <objbase.h>
 
-#include <assert.h>
-
 #define _USE_MATH_DEFINES
-#include <math.h>
-
-#include <float.h>
-#include <stdlib.h>
-#include <time.h>
-#include <string.h>
+#include <cmath>
 
 #include <algorithm>
+#include <cassert>
+#include <cfloat>
 #include <cstdint>
-#include <cmath>
-#include <memory>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <cstring>
 #include <functional>
+#include <memory>
 #include <vector>
 #include <queue>
 
@@ -96,8 +94,8 @@ extern void __cdecl UVAtlasDebugPrintf(unsigned int lvl, _In_z_ _Printf_format_s
 
 #ifndef SAFE_DELETE_ARRAY
 #define SAFE_DELETE_ARRAY(p) { if(p) { delete[] (p);   (p)=nullptr; } }
-#endif    
+#endif
 
 #ifndef SAFE_RELEASE
 #define SAFE_RELEASE(p)      { if(p) { (p)->Release(); (p)=nullptr; } }
-#endif   
+#endif

--- a/UVAtlasTool/Mesh.cpp
+++ b/UVAtlasTool/Mesh.cpp
@@ -22,6 +22,10 @@
 #pragma warning(pop)
 
 #include "Mesh.h"
+
+#include <cstring>
+#include <utility>
+
 #include "SDKMesh.h"
 
 #include <DirectXPackedVector.h>

--- a/UVAtlasTool/Mesh.h
+++ b/UVAtlasTool/Mesh.h
@@ -12,6 +12,7 @@
 
 #include <Windows.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <ostream>

--- a/UVAtlasTool/UVAtlas.cpp
+++ b/UVAtlasTool/UVAtlas.cpp
@@ -20,14 +20,16 @@
 #define NOHELP
 #pragma warning(pop)
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <conio.h>
-
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <memory>
 #include <list>
+
+#include <conio.h>
 
 #include <dxgiformat.h>
 


### PR DESCRIPTION
Reviewed all the C++ standard library header usage and normalized usage for improved conformance.

* ``size_t`` requires ``cstddef``
* ``memcpy``, ``memcpy_s`` is officially in ``cstring``
* Use ``cassert`` instead of ``assert.h``, ``ctime`` instead of ``time.h``, ``cfloat`` instead of ``float.h``
* ``std::move`` is in ``utility``

> The non-standard malloc.h is still being included for ``_aligned_malloc`` / ``_aligned_free``. To be conformant, I should update it to use ``aligned_alloc`` and ``free`` when building for C++17 which is in ``cstdlib``.

Also trimmed trailing whitespace in these files.