### PR TITLE
uvatlastool: add -uv2 switch

### DIFF
--- a/UVAtlasTool/Mesh.cpp
+++ b/UVAtlasTool/Mesh.cpp
@@ -560,7 +560,7 @@ HRESULT Mesh::Clean(_In_ bool breakBowties) noexcept
     mTangents.swap(tans1);
     mBiTangents.swap(tans2);
     mTexCoords.swap(texcoord);
-    mTexCoords.swap(texcoord2);
+    mTexCoords2.swap(texcoord2);
     mColors.swap(colors);
     mBlendIndices.swap(blendIndices);
     mBlendWeights.swap(blendWeights);

--- a/UVAtlasTool/Mesh.h
+++ b/UVAtlasTool/Mesh.h
@@ -63,7 +63,7 @@ public:
 
     HRESULT UpdateAttributes(_In_ size_t nFaces, _In_reads_(nFaces * 3) const uint32_t* attributes) noexcept;
 
-    HRESULT UpdateUVs(_In_ size_t nVerts, _In_reads_(nVerts) const DirectX::XMFLOAT2* uvs) noexcept;
+    HRESULT UpdateUVs(_In_ size_t nVerts, _In_reads_(nVerts) const DirectX::XMFLOAT2* uvs, bool keepOriginal) noexcept;
 
     HRESULT VertexRemap(_In_reads_(nNewVerts) const uint32_t* remap, _In_ size_t nNewVerts) noexcept;
 
@@ -74,7 +74,7 @@ public:
 
     HRESULT ReverseHandedness() noexcept;
 
-    HRESULT VisualizeUVs() noexcept;
+    HRESULT VisualizeUVs(bool useSecondUVs) noexcept;
 
     // Accessors
     const uint32_t* GetAttributeBuffer() const noexcept { return mAttributes.get(); }
@@ -171,6 +171,7 @@ private:
     std::unique_ptr<DirectX::XMFLOAT4[]>        mTangents;
     std::unique_ptr<DirectX::XMFLOAT3[]>        mBiTangents;
     std::unique_ptr<DirectX::XMFLOAT2[]>        mTexCoords;
+    std::unique_ptr<DirectX::XMFLOAT2[]>        mTexCoords2;
     std::unique_ptr<DirectX::XMFLOAT4[]>        mColors;
     std::unique_ptr<DirectX::XMFLOAT4[]>        mBlendIndices;
     std::unique_ptr<DirectX::XMFLOAT4[]>        mBlendWeights;


### PR DESCRIPTION
The ``uvatlastool`` normally replaces any existing texture coordinate channel with the isochart UVs.

With the ``-uv2`` switch, the isochart UVs are placed in a second texture channel if there's already one in the model.

> ``-uv2`` is only supported for SDKMESH. Wavefront OBJ, VBO, and CMO can only store one texture channel.