### PR TITLE
CMake support added for building with MinGW

### DIFF
--- a/.nuget/UVAtlas-config.cmake.in
+++ b/.nuget/UVAtlas-config.cmake.in
@@ -15,7 +15,7 @@ if (ENABLE_USE_EIGEN)
     find_dependency(spectra)
 endif()
 
-if((NOT WIN32) OR VCPKG_TOOLCHAIN)
+if(MINGW OR (NOT WIN32) OR VCPKG_TOOLCHAIN)
     find_dependency(directx-headers CONFIG)
     find_dependency(directxmath CONFIG)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ option(ENABLE_USE_EIGEN "Use the Eigen & BLAS libraries" OFF)
 
 option(ENABLE_CODE_ANALYSIS "Use Static Code Analysis on build" OFF)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -120,7 +120,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 target_include_directories(${PROJECT_NAME} PRIVATE UVAtlas UVAtlas/geodesics UVAtlas/isochart)
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
+if ((${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16") AND (NOT MINGW))
     target_precompile_headers(${PROJECT_NAME} PRIVATE UVAtlas/pch.h)
 endif()
 
@@ -136,7 +136,7 @@ if(MSVC)
     string(REPLACE "/GR " "/GR- " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 endif()
 
-if ((NOT WIN32) OR VCPKG_TOOLCHAIN)
+if (MINGW OR (NOT WIN32) OR VCPKG_TOOLCHAIN)
     message("INFO: Using VCPKG for DirectX-Headers and DirectXMath.")
     find_package(directx-headers CONFIG REQUIRED)
     find_package(directxmath CONFIG REQUIRED)
@@ -200,17 +200,15 @@ if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))
         UVAtlasTool/Mesh.h
         UVAtlasTool/MeshOBJ.cpp
         UVAtlasTool/SDKMesh.h)
-
     target_link_libraries(uvatlastool
         ${PROJECT_NAME}
         ole32.lib version.lib
         Microsoft::DirectXMesh
         Microsoft::DirectXTex
         Microsoft::DirectXMesh::Utilities)
-
     source_group(UVAtlasTool REGULAR_EXPRESSION UVAtlasTool/*.*)
 
-    if (VCPKG_TOOLCHAIN)
+    if (MINGW OR VCPKG_TOOLCHAIN)
       target_link_libraries(uvatlastool Microsoft::DirectXMath)
     endif()
 endif()
@@ -223,10 +221,21 @@ if(MSVC)
 
     if((${CMAKE_SIZEOF_VOID_P} EQUAL 4) AND (NOT ${DIRECTX_ARCH} MATCHES "^arm"))
         foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-          target_compile_options(${t} PRIVATE /arch:SSE2)
           target_link_options(${t} PRIVATE /SAFESEH)
         endforeach()
     endif()
+endif()
+
+if(NOT ${DIRECTX_ARCH} MATCHES "^arm")
+    if (${CMAKE_SIZEOF_VOID_P} EQUAL "4")
+        set(ARCH_SSE2 $<$<CXX_COMPILER_ID:MSVC>:/arch:SSE2> $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse2>)
+    else()
+        set(ARCH_SSE2 $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse2>)
+    endif()
+
+    foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+      target_compile_options(${t} PRIVATE ${ARCH_SSE2})
+    endforeach()
 endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -236,6 +245,12 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(WarningsEXE ${WarningsLib} "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic" "-Wno-switch" "-Wno-switch-enum" "-Wno-exit-time-destructors" "-Wno-switch" "-Wno-switch-enum" "-Wno-language-extension-token" "-Wno-missing-prototypes")
     foreach(t IN LISTS TOOL_EXES)
       target_compile_options(${t} PRIVATE ${WarningsEXE})
+    endforeach()
+endif()
+if(MINGW)
+    foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+      target_compile_options(${t} PRIVATE "-Wno-ignored-attributes")
+      target_link_options(${t} PRIVATE -municode)
     endforeach()
 endif()
 if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
@@ -285,10 +300,11 @@ if(WIN32)
     endforeach()
 
     if(WINDOWS_STORE)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE _WIN32_WINNT=0x0A00 WINAPI_FAMILY=WINAPI_FAMILY_APP)
+      target_compile_definitions(${PROJECT_NAME} PRIVATE _WIN32_WINNT=0x0A00 WINAPI_FAMILY=WINAPI_FAMILY_APP)
     else()
-        target_compile_definitions(${PROJECT_NAME} PRIVATE _WIN32_WINNT=0x0601)
+      target_compile_definitions(${PROJECT_NAME} PRIVATE _WIN32_WINNT=0x0601)
     endif()
+
     foreach(t IN LISTS TOOL_EXES)
       target_compile_definitions(${t} PRIVATE _WIN32_WINNT=0x0601)
     endforeach()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -101,6 +101,17 @@
         "strategy": "external"
       }
     },
+    {
+      "name": "GNUC",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++.exe"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      }
+    },
 
     { "name": "x64-Debug"    , "description": "MSVC for x64 (Debug) Library only", "inherits": [ "base", "x64", "Debug", "MSVC" ] },
     { "name": "x64-Release"  , "description": "MSVC for x64 (Release) Library only", "inherits": [ "base", "x64", "Release", "MSVC" ] },
@@ -144,6 +155,11 @@
     { "name": "x86-Debug-VCPKG-Clang"    , "description": "Clang/LLVM for x86 (Debug) uvatlastool", "inherits": [ "base", "x86", "Debug", "VCPKG", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
     { "name": "x86-Release-VCPKG-Clang"  , "description": "Clang/LLVM for x86 (Release) uvatlastool", "inherits": [ "base", "x86", "Release", "VCPKG", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
     { "name": "arm64-Debug-VCPKG-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) uvatlastool", "inherits": [ "base", "ARM64", "Debug", "VCPKG", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-    { "name": "arm64-Release-VCPKG-Clang", "description": "Clang/LLVM for AArch64 (Release) uvatlastool", "inherits": [ "base", "ARM64", "Release", "VCPKG", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } }
+    { "name": "arm64-Release-VCPKG-Clang", "description": "Clang/LLVM for AArch64 (Release) uvatlastool", "inherits": [ "base", "ARM64", "Release", "VCPKG", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+
+    { "name": "x64-Debug-MinGW"  , "description": "MinG-W64 (Debug)", "inherits": [ "base", "x64", "Debug", "GNUC", "VCPKG" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
+    { "name": "x64-Release-MinGW", "description": "MinG-W64 (Release)", "inherits": [ "base", "x64", "Release", "GNUC", "VCPKG" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
+    { "name": "x86-Debug-MinGW"  , "description": "MinG-W32 (Debug)", "inherits": [ "base", "x86", "Debug", "GNUC", "VCPKG" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
+    { "name": "x86-Release-MinGW", "description": "MinG-W32 (Release)", "inherits": [ "base", "x86", "Release", "GNUC", "VCPKG" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -70,7 +70,6 @@
     {
       "name": "VCPKG",
       "cacheVariables": {
-        "BUILD_TOOLS" : true,
         "CMAKE_TOOLCHAIN_FILE": {
           "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
           "type": "FILEPATH"
@@ -78,6 +77,14 @@
       },
       "hidden": true
     },
+    {
+      "name": "Tools",
+      "cacheVariables": {
+        "BUILD_TOOLS" : true
+      },
+      "hidden": true
+    },
+
 
     {
       "name": "MSVC",
@@ -129,12 +136,12 @@
     { "name": "arm64-Debug-UWP"  , "description": "MSVC for ARM64 (Debug) for UWP", "inherits": [ "base", "ARM64", "Debug", "MSVC", "UWP" ] },
     { "name": "arm64-Release-UWP", "description": "MSVC for ARM64 (Release) for UWP", "inherits": [ "base", "ARM64", "Release", "MSVC", "UWP" ] },
 
-    { "name": "x64-Debug-VCPKG"    , "description": "MSVC for x64 (Debug) uvatlastool", "inherits": [ "base", "x64", "Debug", "VCPKG", "MSVC" ] },
-    { "name": "x64-Release-VCPKG"  , "description": "MSVC for x64 (Release) uvatlastool", "inherits": [ "base", "x64", "Release", "VCPKG", "MSVC" ] },
-    { "name": "x86-Debug-VCPKG"    , "description": "MSVC for x86 (Debug) uvatlastool", "inherits": [ "base", "x86", "Debug", "VCPKG", "MSVC" ] },
-    { "name": "x86-Release-VCPKG"  , "description": "MSVC for x86 (Release) uvatlastool", "inherits": [ "base", "x86", "Release", "VCPKG", "MSVC" ] },
-    { "name": "arm64-Debug-VCPKG"  , "description": "MSVC for ARM64 (Debug) uvatlastool", "inherits": [ "base", "ARM64", "Debug", "VCPKG", "MSVC" ] },
-    { "name": "arm64-Release-VCPKG", "description": "MSVC for ARM64 (Release) uvatlastool", "inherits": [ "base", "ARM64", "Release", "VCPKG", "MSVC" ] },
+    { "name": "x64-Debug-VCPKG"    , "description": "MSVC for x64 (Debug) uvatlastool", "inherits": [ "base", "x64", "Debug", "VCPKG", "MSVC", "Tools" ] },
+    { "name": "x64-Release-VCPKG"  , "description": "MSVC for x64 (Release) uvatlastool", "inherits": [ "base", "x64", "Release", "VCPKG", "MSVC", "Tools" ] },
+    { "name": "x86-Debug-VCPKG"    , "description": "MSVC for x86 (Debug) uvatlastool", "inherits": [ "base", "x86", "Debug", "VCPKG", "MSVC", "Tools" ] },
+    { "name": "x86-Release-VCPKG"  , "description": "MSVC for x86 (Release) uvatlastool", "inherits": [ "base", "x86", "Release", "VCPKG", "MSVC", "Tools" ] },
+    { "name": "arm64-Debug-VCPKG"  , "description": "MSVC for ARM64 (Debug) uvatlastool", "inherits": [ "base", "ARM64", "Debug", "VCPKG", "MSVC", "Tools" ] },
+    { "name": "arm64-Release-VCPKG", "description": "MSVC for ARM64 (Release) uvatlastool", "inherits": [ "base", "ARM64", "Release", "VCPKG", "MSVC", "Tools" ] },
 
     { "name": "x64-Debug-Clang"    , "description": "Clang/LLVM for x64 (Debug) Library only", "inherits": [ "base", "x64", "Debug", "Clang" ] },
     { "name": "x64-Release-Clang"  , "description": "Clang/LLVM for x64 (Release) Library only", "inherits": [ "base", "x64", "Release", "Clang" ] },
@@ -150,12 +157,12 @@
     { "name": "arm64-Debug-UWP-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) for UWP", "inherits": [ "base", "ARM64", "Debug", "Clang", "UWP" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
     { "name": "arm64-Release-UWP-Clang", "description": "Clang/LLVM for AArch64 (Release) for UWP", "inherits": [ "base", "ARM64", "Release", "Clang", "UWP" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
 
-    { "name": "x64-Debug-VCPKG-Clang"    , "description": "Clang/LLVM for x64 (Debug) uvatlastool", "inherits": [ "base", "x64", "Debug", "VCPKG", "Clang" ] },
-    { "name": "x64-Release-VCPKG-Clang"  , "description": "Clang/LLVM for x64 (Release) uvatlastool", "inherits": [ "base", "x64", "Release", "VCPKG", "Clang" ] },
-    { "name": "x86-Debug-VCPKG-Clang"    , "description": "Clang/LLVM for x86 (Debug) uvatlastool", "inherits": [ "base", "x86", "Debug", "VCPKG", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "x86-Release-VCPKG-Clang"  , "description": "Clang/LLVM for x86 (Release) uvatlastool", "inherits": [ "base", "x86", "Release", "VCPKG", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "arm64-Debug-VCPKG-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) uvatlastool", "inherits": [ "base", "ARM64", "Debug", "VCPKG", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-    { "name": "arm64-Release-VCPKG-Clang", "description": "Clang/LLVM for AArch64 (Release) uvatlastool", "inherits": [ "base", "ARM64", "Release", "VCPKG", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "x64-Debug-VCPKG-Clang"    , "description": "Clang/LLVM for x64 (Debug) uvatlastool", "inherits": [ "base", "x64", "Debug", "VCPKG", "Clang", "Tools" ] },
+    { "name": "x64-Release-VCPKG-Clang"  , "description": "Clang/LLVM for x64 (Release) uvatlastool", "inherits": [ "base", "x64", "Release", "VCPKG", "Clang", "Tools" ] },
+    { "name": "x86-Debug-VCPKG-Clang"    , "description": "Clang/LLVM for x86 (Debug) uvatlastool", "inherits": [ "base", "x86", "Debug", "VCPKG", "Clang", "Tools" ], "environment": { "CXXFLAGS": "-m32" } },
+    { "name": "x86-Release-VCPKG-Clang"  , "description": "Clang/LLVM for x86 (Release) uvatlastool", "inherits": [ "base", "x86", "Release", "VCPKG", "Clang", "Tools" ], "environment": { "CXXFLAGS": "-m32" } },
+    { "name": "arm64-Debug-VCPKG-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) uvatlastool", "inherits": [ "base", "ARM64", "Debug", "VCPKG", "Clang", "Tools" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "arm64-Release-VCPKG-Clang", "description": "Clang/LLVM for AArch64 (Release) uvatlastool", "inherits": [ "base", "ARM64", "Release", "VCPKG", "Clang", "Tools" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
 
     { "name": "x64-Debug-MinGW"  , "description": "MinG-W64 (Debug)", "inherits": [ "base", "x64", "Debug", "GNUC", "VCPKG" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
     { "name": "x64-Release-MinGW", "description": "MinG-W64 (Release)", "inherits": [ "base", "x64", "Release", "GNUC", "VCPKG" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },

--- a/UVAtlas/inc/UVAtlas.h
+++ b/UVAtlas/inc/UVAtlas.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#if defined(WIN32) || defined(_WIN32)
+#ifdef _WIN32
 #ifdef _GAMING_XBOX_SCARLETT
 #include <d3d12_xs.h>
 #elif defined(_GAMING_XBOX)

--- a/UVAtlas/isochart/isochartengine.cpp
+++ b/UVAtlas/isochart/isochartengine.cpp
@@ -39,7 +39,7 @@ CIsochartEngine::CIsochartEngine() :
     fExpectAvgL2SquaredStretch(0.f),
     dwExpectChartCount(0),
     m_state(ISOCHART_ST_UNINITILAIZED),
-#ifdef WIN32
+#ifdef _WIN32
     m_hMutex(nullptr),
 #endif
     m_dwOptions(ISOCHARTOPTION::DEFAULT)
@@ -54,14 +54,14 @@ CIsochartEngine::~CIsochartEngine()
     // Free will return with "busy". So loop until free successfully.
     while (FAILED(Free()))
     {
-#ifdef WIN32
+#ifdef _WIN32
         SwitchToThread();
 #else
         std::this_thread::yield();
 #endif
     }
 
-#ifdef WIN32
+#ifdef _WIN32
     if (m_hMutex)
     {
         CloseHandle(m_hMutex);
@@ -71,7 +71,7 @@ CIsochartEngine::~CIsochartEngine()
 
 HRESULT CIsochartEngine::CreateEngineMutex()
 {
-#ifdef WIN32
+#ifdef _WIN32
     m_hMutex = CreateMutexEx(nullptr, nullptr, CREATE_MUTEX_INITIAL_OWNER, SYNCHRONIZE);
     if (!m_hMutex)
     {
@@ -1806,7 +1806,7 @@ HRESULT CIsochartEngine::FillExportFaceAdjacencyBuffer(
 
 HRESULT CIsochartEngine::TryEnterExclusiveSection()
 {
-#ifdef WIN32
+#ifdef _WIN32
     // Other thread is using this object.
     if (WaitForSingleObjectEx(m_hMutex, 0, FALSE) == WAIT_OBJECT_0)
     {
@@ -1823,7 +1823,7 @@ HRESULT CIsochartEngine::TryEnterExclusiveSection()
 
 void  CIsochartEngine::LeaveExclusiveSection()
 {
-#ifdef WIN32
+#ifdef _WIN32
     if (m_hMutex)
     {
         ReleaseMutex(m_hMutex);

--- a/UVAtlas/isochart/isochartengine.h
+++ b/UVAtlas/isochart/isochartengine.h
@@ -247,7 +247,7 @@ namespace Isochart
 
         EngineState m_state;	// Indicate internal state.
 
-#ifdef WIN32
+#ifdef _WIN32
         HANDLE m_hMutex;
 #else
         std::mutex m_mutex;

--- a/UVAtlas/pch.h
+++ b/UVAtlas/pch.h
@@ -51,14 +51,14 @@
 #pragma clang diagnostic ignored "-Wswitch-enum"
 #endif
 
-#if defined(WIN32) || defined(_WIN32)
+#ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
-#define NOMINMAX
+#define NOMINMAX 1
 #define NODRAWTEXT
 #define NOGDI
 #define NOBITMAP
@@ -69,6 +69,10 @@
 
 #include <Windows.h>
 #include <objbase.h>
+
+#ifdef __MINGW32__
+#include <unknwn.h>
+#endif
 
 #ifdef USING_DIRECTX_HEADERS
 #include <directx/dxgiformat.h>
@@ -109,7 +113,7 @@
 #include <random>
 #pragma warning(pop)
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <mutex>
 #include <thread>
 #endif

--- a/UVAtlasTool/Mesh.cpp
+++ b/UVAtlasTool/Mesh.cpp
@@ -2298,17 +2298,17 @@ HRESULT Mesh::ExportToSDKMESH(const wchar_t* szFileName,
                     {
                         strcpy_s(fname, basename.c_str());
                         strcat_s(fname, "_normal");
-                        _makepath_s(m2->NormalTexture, drive, dir, fname, ext);
+                        _makepath_s(m2->NormalTexture, MAX_TEXTURE_NAME, drive, dir, fname, ext);
 
                         strcpy_s(fname, basename.c_str());
                         strcat_s(fname, "_occlusionRoughnessMetallic");
-                        _makepath_s(m2->RMATexture, drive, dir, fname, ext);
+                        _makepath_s(m2->RMATexture, MAX_TEXTURE_NAME, drive, dir, fname, ext);
 
                         if (m0->emissiveColor.x > 0 || m0->emissiveColor.y > 0 || m0->emissiveColor.z > 0)
                         {
                             strcpy_s(fname, basename.c_str());
                             strcat_s(fname, "_emissive");
-                            _makepath_s(m2->EmissiveTexture, drive, dir, fname, ext);
+                            _makepath_s(m2->EmissiveTexture, MAX_TEXTURE_NAME, drive, dir, fname, ext);
                         }
                     }
                 }

--- a/UVAtlasTool/MeshOBJ.cpp
+++ b/UVAtlasTool/MeshOBJ.cpp
@@ -13,7 +13,7 @@
 #pragma warning(push)
 #pragma warning(disable : 4005)
 #define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
+#define NOMINMAX 1
 #define NODRAWTEXT
 #define NOGDI
 #define NOMCX


### PR DESCRIPTION
Since UVAtlas already supports building using GNUC for WSL, added CMakePresets for using MinGW as well:

```
x64-Debug-MinGW
x64-Release-MinGW
x86-Debug-MinGW
x86-Release-MinGW
```

Makes use of VCPKG for DirectXMath and DirectX-Headers since the MinGW has minimal versions of these libraries. Requires the ``VCPKG_ROOT`` envvar set.

It also needs to find DirectXTex and DirectXMesh built with MinGW or the link of ``uvatlastool`` fails.

Also added these CMakePresets:

```
x64-Debug-VCPKG
x64-Release-VCPKG
x86-Debug-VCPKG
x86-Release-VCPKG
arm64-Debug-VCPKG
arm64-Release-VCPKG
```

This is being done to improve compiler conformance for the code.

> Also normalized preprocessor define use to ``_WIN32`` and not ``WIN32``.