### PR TITLE
CMake update for version 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ project (UVAtlas
   HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=512686"
   LANGUAGES CXX)
 
-option(BUILD_TESTING "Build test suite (if present)" ON)
-
 # To build this tool, you need the DirectXTex (http://go.microsoft.com/fwlink/?LinkId=248926) and
 # DirectXMesh (http://go.microsoft.com/fwlink/?LinkID=324981) cmake packages available.
 #
@@ -321,6 +319,7 @@ if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))
     set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT uvatlastool)
 endif()
 
+include(CTest)
 if(BUILD_TESTING AND WIN32 AND (NOT WINDOWS_STORE) AND (EXISTS "${CMAKE_CURRENT_LIST_DIR}/Tests/CMakeLists.txt"))
   enable_testing()
   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/Tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,7 @@ if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))
     set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT uvatlastool)
 endif()
 
+#--- Test suite
 include(CTest)
 if(BUILD_TESTING AND WIN32 AND (NOT WINDOWS_STORE) AND (EXISTS "${CMAKE_CURRENT_LIST_DIR}/Tests/CMakeLists.txt"))
   enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ project (UVAtlas
   HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=512686"
   LANGUAGES CXX)
 
+option(BUILD_TESTING "Build test suite (if present)" ON)
+
 # To build this tool, you need the DirectXTex (http://go.microsoft.com/fwlink/?LinkId=248926) and
 # DirectXMesh (http://go.microsoft.com/fwlink/?LinkID=324981) cmake packages available.
 #
@@ -317,4 +319,9 @@ endif()
 
 if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))
     set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT uvatlastool)
+endif()
+
+if(BUILD_TESTING AND WIN32 AND (NOT WINDOWS_STORE) AND (EXISTS "${CMAKE_CURRENT_LIST_DIR}/Tests/CMakeLists.txt"))
+  enable_testing()
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/Tests)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -195,5 +195,20 @@
     { "name": "x64-Release-Linux",   "description": "WSL Linux x64 (Release)", "inherits": [ "base", "x64", "Release", "VCPKG" ] },
     { "name": "arm64-Debug-Linux",   "description": "WSL Linux ARM64 (Debug)", "inherits": [ "base", "ARM64", "Debug", "VCPKG" ] },
     { "name": "arm64-Release-Linux", "description": "WSL Linux ARM64 (Release)", "inherits": [ "base", "ARM64", "Release", "VCPKG" ] }
+  ],
+  "testPresets": [
+    { "name": "x64-Debug"    , "configurePreset": "x64-Debug" },
+    { "name": "x64-Release"  , "configurePreset": "x64-Release" },
+    { "name": "x86-Debug"    , "configurePreset": "x86-Debug" },
+    { "name": "x86-Release"  , "configurePreset": "x86-Release" },
+    { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug" },
+    { "name": "arm64-Release", "configurePreset": "arm64-Release" },
+
+    { "name": "x64-Debug-Clang"    , "configurePreset": "x64-Debug-Clang" },
+    { "name": "x64-Release-Clang"  , "configurePreset": "x64-Release-Clang" },
+    { "name": "x86-Debug-Clang"    , "configurePreset": "x86-Debug-Clang" },
+    { "name": "x86-Release-Clang"  , "configurePreset": "x86-Release-Clang" },
+    { "name": "arm64-Debug-Clang"  , "configurePreset": "arm64-Debug-Clang" },
+    { "name": "arm64-Release-Clang", "configurePreset": "arm64-Release-Clang" }
   ]
 }


### PR DESCRIPTION
CMake 3.20 allows the removal of some string hacks for ``/Wall`` and ``/GR-`` for ``CMAKE_CXX_FLAGS``.

Also integrates the test suite if present. CTest support added to the test suite in this PR: https://github.com/walbourn/uvatlastest/pull/5