### PR TITLE
Add Spectre-mitigated libraries to the NuGet

### DIFF
--- a/.nuget/uvatlas_desktop_2019.nuspec
+++ b/.nuget/uvatlas_desktop_2019.nuspec
@@ -30,14 +30,38 @@ UVAtlas, a shared source library for creating and packing an isochart texture at
         <file target="native\lib\x86\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\Win32\Debug\*.lib" />
         <file target="native\lib\x86\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\Win32\Debug\*.pdb" />
 
+        <file target="native\lib\x86\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\Win32\DebugSpectre\*.lib" />
+        <file target="native\lib\x86\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\Win32\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x86\Release" src="UVAtlas\Bin\Desktop_2019_Win10\Win32\Release\*.lib" />
         <file target="native\lib\x86\Release" src="UVAtlas\Bin\Desktop_2019_Win10\Win32\Release\*.pdb" />
+
+        <file target="native\lib\x86\Release" src="UVAtlas\Bin\Desktop_2019_Win10\Win32\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x86\Release" src="UVAtlas\Bin\Desktop_2019_Win10\Win32\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\x64\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\x64\Debug\*.lib" />
         <file target="native\lib\x64\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\x64\Debug\*.pdb" />
 
+        <file target="native\lib\x64\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\x64\DebugSpectre\*.lib" />
+        <file target="native\lib\x64\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\x64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x64\Release" src="UVAtlas\Bin\Desktop_2019_Win10\x64\Release\*.lib" />
         <file target="native\lib\x64\Release" src="UVAtlas\Bin\Desktop_2019_Win10\x64\Release\*.pdb" />
+
+        <file target="native\lib\x64\Release" src="UVAtlas\Bin\Desktop_2019_Win10\x64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x64\Release" src="UVAtlas\Bin\Desktop_2019_Win10\x64\ReleaseSpectre\*.pdb" />
+
+        <file target="native\lib\ARM64\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\ARM64\Debug\*.lib" />
+        <file target="native\lib\ARM64\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\ARM64\Debug\*.pdb" />
+
+        <file target="native\lib\ARM64\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\ARM64\DebugSpectre\*.lib" />
+        <file target="native\lib\ARM64\Debug" src="UVAtlas\Bin\Desktop_2019_Win10\ARM64\DebugSpectre\*.pdb" />
+
+        <file target="native\lib\ARM64\Release" src="UVAtlas\Bin\Desktop_2019_Win10\ARM64\Release\*.lib" />
+        <file target="native\lib\ARM64\Release" src="UVAtlas\Bin\Desktop_2019_Win10\ARM64\Release\*.pdb" />
+
+        <file target="native\lib\ARM64\Release" src="UVAtlas\Bin\Desktop_2019_Win10\ARM64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\ARM64\Release" src="UVAtlas\Bin\Desktop_2019_Win10\ARM64\ReleaseSpectre\*.pdb" />
 
         <file src=".nuget/uvatlas_desktop_2019.targets" target="build\native" />
 
@@ -45,3 +69,4 @@ UVAtlas, a shared source library for creating and packing an isochart texture at
 
     </files>
 </package>
+Wz

--- a/.nuget/uvatlas_desktop_2019.targets
+++ b/.nuget/uvatlas_desktop_2019.targets
@@ -16,12 +16,14 @@
 
   <PropertyGroup>
     <uvatlas-LibPath>$(MSBuildThisFileDirectory)..\..\native\lib\$(PlatformTarget)\$(NuGetConfiguration)</uvatlas-LibPath>
+    <uvatlas-LibName Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">UVAtlas_Spectre</uvatlas-LibName>
+    <uvatlas-LibName Condition="'$(uvatlas-LibName)'==''">UVAtlas</uvatlas-LibName>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(uvatlas-LibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>UVAtlas.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(uvatlas-LibName).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/UVAtlas/UVAtlas_2019_Win10.vcxproj
+++ b/UVAtlas/UVAtlas_2019_Win10.vcxproj
@@ -182,6 +182,11 @@
     <IntDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>UVAtlas</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>UVAtlas_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/UVAtlas/UVAtlas_2022_Win10.vcxproj
+++ b/UVAtlas/UVAtlas_2022_Win10.vcxproj
@@ -182,6 +182,11 @@
     <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>UVAtlas</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>UVAtlas_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>


### PR DESCRIPTION
Customers using the BinSkim Microsoft security tool will get flagged when using static C++ libraries not built using ``/Qspectre``. This adds the alternative flavor of the libraries to the **uvatlas_desktop_2019** NuGet package. The targets automatically selects the Spectre version when building with SpectreMitigations enabled.

Also adds ARM64 support to **uvatlas_desktop_2019** since there's no reason to need a **uvatlas_desktop_win10** variant (i.e. no DX11 .vs DX12 behavior).

> This will increase package size to ~20MB which is reasonable.