### PR TITLE
December 15, 2022

### DIFF
--- a/.nuget/uvatlas_desktop_2019.nuspec
+++ b/.nuget/uvatlas_desktop_2019.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Windows desktop applications using Visual Studio 2019 or Visual Studio 2022.
 
 UVAtlas, a shared source library for creating and packing an isochart texture atlas.</description>
-        <releaseNotes>Matches the October 17, 2022 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the December 15, 2022 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkID=512686</projectUrl>
         <repository type="git" url="https://github.com/microsoft/UVAtlas.git" />
         <icon>images\icon.jpg</icon>
@@ -69,4 +69,3 @@ UVAtlas, a shared source library for creating and packing an isochart texture at
 
     </files>
 </package>
-Wz

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,14 @@ Release available for download on [GitHub](https://github.com/microsoft/UVAtlas/
 
 ## Release History
 
+### December 15, 2022
+* CMake project updated to require 3.20 or later
+* CMake and MSBuild project updates
+* Added Azure Dev Ops Pipeline YAML files
+* Test suite updated with CTest support
+* Spectre-mitigated libraries added to NuGet package
+* uvatlastool: added switches ``-m`` and ``-vn``; fixed bug with ``-c -wf`` missing ``.mtl`` output file
+
 ### October 17, 2022
 * Minor CMakePresets update
 * Code review (more use of constexpr)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,8 +11,9 @@ Release available for download on [GitHub](https://github.com/microsoft/UVAtlas/
 * CMake and MSBuild project updates
 * Added Azure Dev Ops Pipeline YAML files
 * Test suite updated with CTest support
-* Spectre-mitigated libraries added to NuGet package
+* Spectre-mitigated libraries and ARM64 support added to NuGet package
 * uvatlastool: added switches ``-m`` and ``-vn``; fixed bug with ``-c -wf`` missing ``.mtl`` output file
+* uvatlastool: Updated for December 2022 DirectXTex & DirectXMesh releases
 
 ### October 17, 2022
 * Minor CMakePresets update

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ http://go.microsoft.com/fwlink/?LinkID=512686
 
 Copyright (c) Microsoft Corporation.
 
-**October 17, 2022**
+**December 15, 2022**
 
 This package contains UVAtlas, a shared source library for creating and packing an isochart texture atlas.
 

--- a/UVAtlasTool/UVAtlasTool_2019.vcxproj
+++ b/UVAtlasTool/UVAtlasTool_2019.vcxproj
@@ -299,14 +299,14 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\directxmesh_desktop_2019.2022.10.18.1\build\native\directxmesh_desktop_2019.targets" Condition="Exists('..\packages\directxmesh_desktop_2019.2022.10.18.1\build\native\directxmesh_desktop_2019.targets')" />
-    <Import Project="..\packages\directxtex_desktop_2019.2022.10.18.1\build\native\directxtex_desktop_2019.targets" Condition="Exists('..\packages\directxtex_desktop_2019.2022.10.18.1\build\native\directxtex_desktop_2019.targets')" />
+    <Import Project="..\packages\directxmesh_desktop_2019.2022.12.18.1\build\native\directxmesh_desktop_2019.targets" Condition="Exists('..\packages\directxmesh_desktop_2019.2022.12.18.1\build\native\directxmesh_desktop_2019.targets')" />
+    <Import Project="..\packages\directxtex_desktop_2019.2022.12.18.1\build\native\directxtex_desktop_2019.targets" Condition="Exists('..\packages\directxtex_desktop_2019.2022.12.18.1\build\native\directxtex_desktop_2019.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\directxmesh_desktop_2019.2022.10.18.1\build\native\directxmesh_desktop_2019.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxmesh_desktop_2019.2022.10.18.1\build\native\directxmesh_desktop_2019.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_desktop_2019.2022.10.18.1\build\native\directxtex_desktop_2019.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2019.2022.10.18.1\build\native\directxtex_desktop_2019.targets'))" />
+    <Error Condition="!Exists('..\packages\directxmesh_desktop_2019.2022.12.18.1\build\native\directxmesh_desktop_2019.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxmesh_desktop_2019.2022.12.18.1\build\native\directxmesh_desktop_2019.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_desktop_2019.2022.12.18.1\build\native\directxtex_desktop_2019.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2019.2022.12.18.1\build\native\directxtex_desktop_2019.targets'))" />
   </Target>
 </Project>

--- a/UVAtlasTool/UVAtlasTool_2022.vcxproj
+++ b/UVAtlasTool/UVAtlasTool_2022.vcxproj
@@ -305,14 +305,14 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\directxmesh_desktop_2019.2022.10.18.1\build\native\directxmesh_desktop_2019.targets" Condition="Exists('..\packages\directxmesh_desktop_2019.2022.10.18.1\build\native\directxmesh_desktop_2019.targets')" />
-    <Import Project="..\packages\directxtex_desktop_2019.2022.10.18.1\build\native\directxtex_desktop_2019.targets" Condition="Exists('..\packages\directxtex_desktop_2019.2022.10.18.1\build\native\directxtex_desktop_2019.targets')" />
+    <Import Project="..\packages\directxmesh_desktop_2019.2022.12.18.1\build\native\directxmesh_desktop_2019.targets" Condition="Exists('..\packages\directxmesh_desktop_2019.2022.12.18.1\build\native\directxmesh_desktop_2019.targets')" />
+    <Import Project="..\packages\directxtex_desktop_2019.2022.12.18.1\build\native\directxtex_desktop_2019.targets" Condition="Exists('..\packages\directxtex_desktop_2019.2022.12.18.1\build\native\directxtex_desktop_2019.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\directxmesh_desktop_2019.2022.10.18.1\build\native\directxmesh_desktop_2019.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxmesh_desktop_2019.2022.10.18.1\build\native\directxmesh_desktop_2019.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_desktop_2019.2022.10.18.1\build\native\directxtex_desktop_2019.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2019.2022.10.18.1\build\native\directxtex_desktop_2019.targets'))" />
+    <Error Condition="!Exists('..\packages\directxmesh_desktop_2019.2022.12.18.1\build\native\directxmesh_desktop_2019.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxmesh_desktop_2019.2022.12.18.1\build\native\directxmesh_desktop_2019.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_desktop_2019.2022.12.18.1\build\native\directxtex_desktop_2019.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_2019.2022.12.18.1\build\native\directxtex_desktop_2019.targets'))" />
   </Target>
 </Project>

--- a/UVAtlasTool/packages.config
+++ b/UVAtlasTool/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxmesh_desktop_2019" version="2022.10.18.1" targetFramework="native" />
-  <package id="directxtex_desktop_2019" version="2022.10.18.1" targetFramework="native" />
+  <package id="directxmesh_desktop_2019" version="2022.12.18.1" targetFramework="native" />
+  <package id="directxtex_desktop_2019" version="2022.12.18.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
* CMake project updated to require 3.20 or later
* CMake and MSBuild project updates
* Added Azure Dev Ops Pipeline YAML files
* Test suite updated with CTest support
* Spectre-mitigated libraries and ARM64 support added to NuGet package
* uvatlastool: added switches ``-m`` and ``-vn``; fixed bug with ``-c -wf`` missing ``.mtl`` output file
* uvatlastool: Updated for December 2022 DirectXTex & DirectXMesh releases