### PR TITLE
Fix build break for Debug on WSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ option(ENABLE_USE_EIGEN "Use the Eigen & BLAS libraries" OFF)
 # https://devblogs.microsoft.com/cppblog/spectre-mitigations-in-msvc/
 option(ENABLE_SPECTRE_MITIGATION "Build using /Qspectre for MSVC" OFF)
 
+option(DISABLE_MSVC_ITERATOR_DEBUGGING "Disable iterator debugging in Debug configurations with the MSVC CRT" OFF)
+
 option(ENABLE_CODE_ANALYSIS "Use Static Code Analysis on build" OFF)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -335,6 +337,12 @@ if(WIN32)
     foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
       target_compile_definitions(${t} PRIVATE _UNICODE UNICODE _WIN32_WINNT=${WINVER})
     endforeach()
+
+    if(DISABLE_MSVC_ITERATOR_DEBUGGING)
+      foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+        target_compile_definitions(${t} PRIVATE _ITERATOR_DEBUG_LEVEL=0)
+      endforeach()
+    endif()
 endif()
 
 if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))

--- a/UVAtlas/isochart/UVAtlas.cpp
+++ b/UVAtlas/isochart/UVAtlas.cpp
@@ -1831,7 +1831,7 @@ HRESULT __cdecl DirectX::UVAtlasApplyRemap(
 
 
 //-------------------------------------------------------------------------------------
-#ifdef _DEBUG
+#if defined(_WIN32) && defined(_DEBUG)
 _Use_decl_annotations_
 void __cdecl UVAtlasDebugPrintf(unsigned int lvl, const char* szFormat, ...)
 {
@@ -1856,4 +1856,4 @@ void __cdecl UVAtlasDebugPrintf(unsigned int lvl, const char* szFormat, ...)
 
     OutputDebugStringA(strB);
 }
-#endif // _DEBUG
+#endif // _WIN32 && _DEBUG

--- a/build/UVAtlas-GitHub-WSL-11.yml
+++ b/build/UVAtlas-GitHub-WSL-11.yml
@@ -90,12 +90,22 @@ jobs:
         }
 
   - task: CMake@1
-    displayName: CMake UVAtlas
+    displayName: CMake UVAtlas (Config) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
   - task: CMake@1
-    displayName: CMake UVAtlas (Build)
+    displayName: CMake UVAtlas (Build) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out -v
+  - task: CMake@1
+    displayName: CMake UVAtlas (Config) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+  - task: CMake@1
+    displayName: CMake UVAtlas (Build) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v

--- a/build/UVAtlas-GitHub-WSL.yml
+++ b/build/UVAtlas-GitHub-WSL.yml
@@ -90,12 +90,22 @@ jobs:
         }
 
   - task: CMake@1
-    displayName: CMake UVAtlas
+    displayName: CMake UVAtlas (Config) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
   - task: CMake@1
-    displayName: CMake UVAtlas (Build)
+    displayName: CMake UVAtlas (Build) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out -v
+  - task: CMake@1
+    displayName: CMake UVAtlas (Config) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+  - task: CMake@1
+    displayName: CMake UVAtlas (Build) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v


### PR DESCRIPTION
When I updated CMakeLists.txt to make sure it defined ``_DEBUG`` for non-MSVC compilers, this enabled some debug paths on non-Win32 builds that won't build due to the use of ``OutputDebugString``. This updates the guards to include both ``_DEBUG`` and ``_WIN32``.

Also updates the WSL build pipelines to validate both Debug and Release configurations.

In addition, this PR introduces a new CMake build option ``DISABLE_MSVC_ITERATOR_DEBUGGING`` to allow clients to disable MSVC's iterator debugging in Debug configuration since this is now the 'default' for clang/LLVM for Windows builds even when not using the ``clang-cl`` driver.