### PR TITLE
Fix PCH bug for Xbox scenarios

### DIFF
--- a/UVAtlas/inc/UVAtlas.h
+++ b/UVAtlas/inc/UVAtlas.h
@@ -18,7 +18,11 @@
 #include <d3d11_x.h>
 #else
 #include <Windows.h>
+#ifdef USING_DIRECTX_HEADERS
+#include <directx/dxgiformat.h>
+#else
 #include <dxgiformat.h>
+#endif
 #endif
 #else // !WIN32
 #include <directx/dxgiformat.h>

--- a/UVAtlas/pch.h
+++ b/UVAtlas/pch.h
@@ -75,9 +75,6 @@
 #include <unknwn.h>
 #endif
 
-#ifdef USING_DIRECTX_HEADERS
-#include <directx/dxgiformat.h>
-#endif
 #else // !WIN32
 #include <wsl/winadapter.h>
 #include <directx/d3d12.h>


### PR DESCRIPTION
Fixes a build break when building for the Xbox platform while ``USING_DIRECTX_HEADERS`` is defined.