### PR TITLE
CMake minor cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ cmake_minimum_required (VERSION 3.20)
 
 set(UVATLAS_VERSION 1.8.4)
 
+if(DEFINED XBOX_CONSOLE_TARGET)
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+endif()
+
 project (UVAtlas
   VERSION ${UVATLAS_VERSION}
   DESCRIPTION "UVAtlas Isochart Atlas Library"
@@ -184,7 +188,11 @@ if(DEFINED XBOX_CONSOLE_TARGET)
             message(FATAL_ERROR "Microsoft GDK with Xbox Extensions environment needs to be set for Xbox One.")
         endif()
         target_compile_definitions(${PROJECT_NAME} PUBLIC _GAMING_XBOX _GAMING_XBOX_XBOXONE)
+    else()
+        message(FATAL_ERROR "Unknown XBOX_CONSOLE_TARGET")
     endif()
+elseif(WINDOWS_STORE)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC WINAPI_FAMILY=WINAPI_FAMILY_APP)
 endif()
 
 #--- Package
@@ -379,10 +387,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 endif()
 
 if(WIN32)
-    if(WINDOWS_STORE)
-      target_compile_definitions(${PROJECT_NAME} PRIVATE WINAPI_FAMILY=WINAPI_FAMILY_APP)
-    endif()
-
     if(WINDOWS_STORE OR (${DIRECTX_ARCH} MATCHES "^arm64") OR (DEFINED XBOX_CONSOLE_TARGET))
         set(WINVER 0x0A00)
     elseif(${DIRECTX_ARCH} MATCHES "^arm")


### PR DESCRIPTION
The XBOX_CONSOLE_TARGET variable can be set to ``scarlett`` or ``xboxone`` if built in the appropriate Developer Command Prompt. We don't support ``durango`` for this library anymore.
