### PR TITLE
Update CMake to use OpenMP via built-in support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,15 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
 
+if(UVATLAS_USE_OPENMP)
+  find_package(OpenMP)
+  if(OpenMP_CXX_FOUND)
+    target_link_libraries(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_CXX)
+  else()
+    set(UVATLAS_USE_OPENMP OFF)
+  endif()
+endif()
+
 target_include_directories(${PROJECT_NAME} PRIVATE UVAtlas UVAtlas/geodesics UVAtlas/isochart)
 
 if(NOT MINGW)
@@ -251,6 +260,10 @@ if(BUILD_TOOLS AND WIN32)
         Microsoft::DirectXMesh::Utilities)
     source_group(uvatlastool REGULAR_EXPRESSION UVAtlasTool/*.*)
 
+    if(UVATLAS_USE_OPENMP)
+      target_link_libraries(uvatlastool OpenMP::OpenMP_CXX)
+    endif()
+
     if(directxmath_FOUND)
       target_link_libraries(uvatlastool Microsoft::DirectXMath)
     endif()
@@ -367,8 +380,9 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     endif()
 
     if(UVATLAS_USE_OPENMP)
+        # OpenMP in MSVC is not compatible with /permissive- unless you disable two-phase lookup
         foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-          target_compile_options(${t} PRIVATE /openmp /Zc:twoPhase-)
+          target_compile_options(${t} PRIVATE /Zc:twoPhase-)
         endforeach()
     endif()
 

--- a/UVAtlas/isochart/isochartengine.cpp
+++ b/UVAtlas/isochart/isochartengine.cpp
@@ -311,9 +311,9 @@ HRESULT CIsochartEngine::ParameterizeChartsInHeapParallelized(
             for (int n = 0; n < static_cast<int>(parent.size()); ++n)
             {
                 if (FAILED(hrOut)) // for the other threads
-                    break;
+                    continue;
 
-                auto pChart = parent[n];
+                auto pChart = parent[static_cast<size_t>(n)];
                 assert(pChart != nullptr);
                 _Analysis_assume_(pChart != nullptr);
 
@@ -323,7 +323,7 @@ HRESULT CIsochartEngine::ParameterizeChartsInHeapParallelized(
                 if (FAILED(hr))
                 {
                     hrOut = hr; // doesn't need pragma atomic as all changes to hrOut are to set it to FAILED
-                    break;
+                    continue;
                 }
 
                 // If current chart has been partitoned, just children add to heap to be

--- a/build/UVAtlas-config.cmake.in
+++ b/build/UVAtlas-config.cmake.in
@@ -3,12 +3,6 @@
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
 include(CMakeFindDependencyMacro)
 
-set(BUILD_TOOLS @BUILD_TOOLS@)
-if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))
-    find_dependency(directxmesh)
-    find_dependency(directxtex)
-endif()
-
 set(UVATLAS_USE_OPENMP @UVATLAS_USE_OPENMP@)
 if(UVATLAS_USE_OPENMP)
     find_dependency(OpenMP)

--- a/build/UVAtlas-config.cmake.in
+++ b/build/UVAtlas-config.cmake.in
@@ -9,6 +9,11 @@ if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))
     find_dependency(directxtex)
 endif()
 
+set(UVATLAS_USE_OPENMP @UVATLAS_USE_OPENMP@)
+if(UVATLAS_USE_OPENMP)
+    find_dependency(OpenMP)
+endif()
+
 set(ENABLE_USE_EIGEN @ENABLE_USE_EIGEN@)
 if (ENABLE_USE_EIGEN)
     find_dependency(Eigen3)


### PR DESCRIPTION
This updates the CMake project to use OpenMP via the built-in CMake support when the UVATLAS_USE_OPENMP build option is set. This uses a find_package to determine OpenMP support (CMake 3.9 or later), which means it can now build w/ OpenMP with MSVC, clang/LLVM for Windows, MinGW, and GNUC toolsets.