### PR TITLE
CMake target file fix

### DIFF
--- a/build/UVAtlas-config.cmake.in
+++ b/build/UVAtlas-config.cmake.in
@@ -14,7 +14,7 @@ if (ENABLE_USE_EIGEN)
     find_dependency(spectra)
 endif()
 
-if(MINGW OR (NOT WIN32) OR VCPKG_TOOLCHAIN)
+if(MINGW OR (NOT WIN32))
     find_dependency(directx-headers CONFIG)
     find_dependency(directxmath CONFIG)
 endif()


### PR DESCRIPTION
The CMakeLists.txt no longer mandates both **directxmath** and **directx-headers** packages be found unless building with MinGW or for Linux. This fixes the behavior for CMake clients consuming this package from VCPKG.