### PR TITLE
CMake targets fixes for optional vs. required packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if(ENABLE_USE_EIGEN)
     message(STATUS "Using Eigen3 & Spectra for CSymmetricMatrix::GetEigen.")
     find_package(Eigen3 REQUIRED)
     find_package(spectra REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PRIVATE Eigen3::Eigen Spectra::Spectra)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen Spectra::Spectra)
     target_compile_definitions(${PROJECT_NAME} PRIVATE UVATLAS_USE_EIGEN)
 endif()
 
@@ -254,7 +254,7 @@ if(BUILD_TOOLS AND WIN32)
         UVAtlasTool/Mesh.h
         UVAtlasTool/MeshOBJ.cpp
         UVAtlasTool/SDKMesh.h)
-    target_link_libraries(uvatlastool
+    target_link_libraries(uvatlastool PRIVATE
         ${PROJECT_NAME}
         ole32.lib version.lib
         Microsoft::DirectXMesh
@@ -263,11 +263,11 @@ if(BUILD_TOOLS AND WIN32)
     source_group(uvatlastool REGULAR_EXPRESSION UVAtlasTool/*.*)
 
     if(UVATLAS_USE_OPENMP)
-      target_link_libraries(uvatlastool OpenMP::OpenMP_CXX)
+      target_link_libraries(uvatlastool PRIVATE OpenMP::OpenMP_CXX)
     endif()
 
     if(directxmath_FOUND)
-      target_link_libraries(uvatlastool Microsoft::DirectXMath)
+      target_link_libraries(uvatlastool PRIVATE Microsoft::DirectXMath)
     endif()
 endif()
 

--- a/build/UVAtlas-config.cmake.in
+++ b/build/UVAtlas-config.cmake.in
@@ -15,8 +15,11 @@ if (ENABLE_USE_EIGEN)
 endif()
 
 if(MINGW OR (NOT WIN32))
-    find_dependency(directx-headers CONFIG)
-    find_dependency(directxmath CONFIG)
+    find_dependency(directx-headers)
+    find_dependency(directxmath)
+else()
+    find_package(directx-headers CONFIG QUIET)
+    find_package(directxmath CONFIG QUIET)
 endif()
 
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
With the changes to make use of DirectXMath & DirectX-Headers 'optional' for VCPKG scenarios unless using MinGW -or- Linux, the generated targets file needed more robust handling of these targets.

Also made sure that explicit 'scope' is used consistently with all CMake ``target_`` commands.