### PR TITLE
Suppress some additional clang v16 warnings when upgrading to clangcl

### DIFF
--- a/UVAtlas/pch.h
+++ b/UVAtlas/pch.h
@@ -50,6 +50,8 @@
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
 #pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
The CMake scenario already disables the new clang v16 warning, but if you upgrade the VCXPROJ project to clangcl, it reappears.