### PR TITLE
Fix build breaks for DEBUG builds

### DIFF
--- a/UVAtlas/isochart/UVAtlas.cpp
+++ b/UVAtlas/isochart/UVAtlas.cpp
@@ -115,7 +115,7 @@ namespace
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning( suppress : 4127 )
+#pragma warning( disable : 4127 )
 #endif
         if ((sizeof(IndexType) == sizeof(uint16_t)) && (*nNewVerts > 0x0fffe))
         {

--- a/UVAtlas/isochart/imtcomputation.cpp
+++ b/UVAtlas/isochart/imtcomputation.cpp
@@ -1488,6 +1488,7 @@ Isochart::IMTFromTextureMapEx(
 
     memset(tempSumIMT, 0, sizeof(double) * IMT_DIM);
 
+    double dTotal2DArea = 0;
     double dPieceArea = 0;
     for (size_t ii = 0; ii < dwRowLineCount - 1; ii++)
     {
@@ -1517,9 +1518,11 @@ Isochart::IMTFromTextureMapEx(
                 tempSumIMT[kk] += tempIMT[kk];
             }
 
+            dTotal2DArea += dPieceArea;
         }
     }
 
+    std::ignore = dTotal2DArea;
     DPF(3, "2d area by formal %f", double(f2dArea));
     DPF(3, "integrated 2d area %f", dTotal2DArea);
 

--- a/UVAtlas/isochart/isochartengine.cpp
+++ b/UVAtlas/isochart/isochartengine.cpp
@@ -1263,6 +1263,8 @@ HRESULT CIsochartEngine::ApplyInitEngine(
         delete pRootChart;
         return E_OUTOFMEMORY;
     }
+    size_t dwTestVertexCount = 0;
+    size_t dwTestFaceCount = 0;
     while (!m_currentChartHeap.empty())
     {
         CIsochartMesh* pChart = m_currentChartHeap.cutTopData();
@@ -1310,9 +1312,13 @@ HRESULT CIsochartEngine::ApplyInitEngine(
                 delete pChart;
                 return E_OUTOFMEMORY;
             }
+            dwTestVertexCount += pChart->GetVertexNumber();
+            dwTestFaceCount += pChart->GetFaceNumber();
         }
     }
 
+    std::ignore = dwTestVertexCount;
+    std::ignore = dwTestFaceCount;
     DPF(3, "Old Vert Number is %zu, New Vert Number is %zu",
         baseInfo.dwVertexCount,
         dwTestVertexCount);
@@ -1700,6 +1706,7 @@ HRESULT CIsochartEngine::FillExportFaceIndexBuffer(
 {
     assert(pvFaceBuffer != nullptr);
 
+    uint32_t dwFaceId = 0;
     size_t dwOffset = 0;
 
     auto pBaseFaces = reinterpret_cast<INDEXTYPE*>(pvFaceBuffer->data());
@@ -1724,10 +1731,12 @@ HRESULT CIsochartEngine::FillExportFaceIndexBuffer(
                 = static_cast<INDEXTYPE>(pChartFaceBuffer[j].dwVertexID[2]
                     + dwOffset);
 
+            dwFaceId++;
         }
         dwOffset += pChart->GetVertexNumber();
     }
 
+    std::ignore = dwFaceId;
     assert(dwFaceId == m_baseInfo.dwFaceCount);
 
     return S_OK;

--- a/UVAtlas/isochart/meshoptimizestretch.cpp
+++ b/UVAtlas/isochart/meshoptimizestretch.cpp
@@ -769,6 +769,7 @@ HRESULT CIsochartMesh::OptimizeGeoLnInfiniteStretch(
         return hr;
     }
 
+    size_t dwBoundaryInfFaces = 0;
     if (bCanOptimize)
     {
         if (optimizeInfo.dwInfinitStretchVertexCount == 0)
@@ -810,6 +811,12 @@ HRESULT CIsochartMesh::OptimizeGeoLnInfiniteStretch(
                 optimizeInfo.dwInfinitStretchVertexCount++;
                 optimizeInfo.fInfinitFacesArea +=
                     m_baseInfo.pfFaceAreaArray[m_pFaces[i].dwIDInRootMesh];
+
+                bool bBoundary =
+                    m_pVerts[m_pFaces[i].dwVertexID[0]].bIsBoundary
+                    || m_pVerts[m_pFaces[i].dwVertexID[1]].bIsBoundary
+                    || m_pVerts[m_pFaces[i].dwVertexID[2]].bIsBoundary;
+                dwBoundaryInfFaces += (bBoundary ? 1 : 0);
             }
             else if (optimizeInfo.pfFaceStretch[i] > m_baseInfo.fExpectAvgL2SquaredStretch)
             {
@@ -835,6 +842,7 @@ HRESULT CIsochartMesh::OptimizeGeoLnInfiniteStretch(
 
     if (!bSucceed)
     {
+        std::ignore = dwBoundaryInfFaces;
         DPF(1, "Infinite Optimize failed, %zu Internal infinite vertices,%zu boundary vert",
             optimizeInfo.dwInfinitStretchVertexCount - dwBoundaryInfFaces,
             dwBoundaryInfFaces);

--- a/UVAtlas/pch.h
+++ b/UVAtlas/pch.h
@@ -105,6 +105,7 @@
 #include <utility>
 #include <vector>
 #include <queue>
+#include <tuple>
 
 #ifdef UVATLAS_USE_EIGEN
 #ifdef _MSC_VER

--- a/build/UVAtlas-GitHub-Test-Dev17.yml
+++ b/build/UVAtlas-GitHub-Test-Dev17.yml
@@ -29,14 +29,16 @@ jobs:
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 1
   steps:
-  - checkout: none
+  - checkout: self
+    clean: true
+    fetchTags: false
+    path: UVAtlas
   - task: DeleteFiles@1
     displayName: Delete files
     inputs:
       Contents: |
         DirectXTex\**
         DirectXMesh\**
-        UVAtlas\**
         Tests\**
 
       RemoveDotFiles: true
@@ -46,7 +48,6 @@ jobs:
       script: |
         git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
         git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
-        git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/UVAtlas.git
 
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
@@ -115,14 +116,16 @@ jobs:
   displayName: 'CMake BUILD_TESTING=ON'
   timeoutInMinutes: 120
   steps:
-  - checkout: none
+  - checkout: self
+    clean: true
+    fetchTags: false
+    path: UVAtlas
   - task: DeleteFiles@1
     displayName: Delete files
     inputs:
       Contents: |
         DirectXTex\**
         DirectXMesh\**
-        UVAtlas\**
         Tests\**
 
       RemoveDotFiles: true
@@ -132,7 +135,6 @@ jobs:
       script: |
         git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
         git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
-        git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/UVAtlas.git
 
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true

--- a/build/UVAtlas-GitHub-Test-Dev17.yml
+++ b/build/UVAtlas-GitHub-Test-Dev17.yml
@@ -35,34 +35,25 @@ jobs:
     clean: true
     fetchTags: false
     path: 's/UVAtlas'
-  - task: DeleteFiles@1
-    displayName: Delete files
-    inputs:
-      Contents: |
-        DirectXTex\**
-        DirectXMesh\**
-        Tests\**
-
-      RemoveDotFiles: true
   - task: CmdLine@2
     displayName: Fetch Libraries
     inputs:
       script: |
-        git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
-        git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
+        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
+        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
 
-      workingDirectory: $(Build.SourcesDirectory)
+      workingDirectory: $(Pipeline.Workspace)/s
       failOnStderr: true
   - task: CmdLine@2
     displayName: Fetch Tests
     inputs:
-      script: git clone --quiet https://%GITHUB_PAT%@github.com/walbourn/uvatlastest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)/UVAtlas
+      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/uvatlastest.git Tests
+      workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2022.sln 32dbg
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
+      solution: Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
@@ -71,7 +62,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solutionxtuvatlas_Desktop_2022.sln 32rel
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
+      solution: Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
@@ -80,7 +71,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2022.sln 64dbg
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
+      solution: Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
@@ -89,7 +80,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2022.sln 64rel
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
+      solution: Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
@@ -98,7 +89,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2022.sln arm64dbg
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
+      solution: Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64
@@ -107,7 +98,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2022.sln arm64rel
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
+      solution: Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64
@@ -124,29 +115,20 @@ jobs:
     clean: true
     fetchTags: false
     path: 's/UVAtlas'
-  - task: DeleteFiles@1
-    displayName: Delete files
-    inputs:
-      Contents: |
-        DirectXTex\**
-        DirectXMesh\**
-        Tests\**
-
-      RemoveDotFiles: true
   - task: CmdLine@2
     displayName: Fetch Libraries
     inputs:
       script: |
-        git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
-        git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
+        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
+        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
 
-      workingDirectory: $(Build.SourcesDirectory)
+      workingDirectory: $(Pipeline.Workspace)/s
       failOnStderr: true
   - task: CmdLine@2
     displayName: Fetch Tests
     inputs:
-      script: git clone --quiet https://%GITHUB_PAT%@github.com/walbourn/uvatlastest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)/UVAtlas
+      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/uvatlastest.git Tests
+      workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
   - task: ChocolateyCommand@0
     displayName: Install Ninja
@@ -173,12 +155,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; x64-Debug) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Debug
   - task: CMake@1
     displayName: CMake (MSVC; x64-Debug) Build
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Debug -v
   - task: DeleteFiles@1
     inputs:
@@ -186,12 +168,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; x64-Release) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Release
   - task: CMake@1
     displayName: CMake (MSVC; x64-Release) Build
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Release -v
   - task: DeleteFiles@1
     inputs:
@@ -199,12 +181,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Debug) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Debug-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Debug) Build
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -212,12 +194,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Release) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Release-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Release) Build
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Release-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -236,12 +218,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Debug) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64-Debug-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Debug) Build
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -249,12 +231,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Release) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64-Release-Clang
   - task: CMake@1
     # This is disabled to avoid an ICE with clang v15.0.1
     displayName: CMake (clang/LLVM; arm64-Release) Build
     enabled: false
     inputs:
-      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64-Release-Clang -v

--- a/build/UVAtlas-GitHub-Test-Dev17.yml
+++ b/build/UVAtlas-GitHub-Test-Dev17.yml
@@ -34,7 +34,7 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-    path: UVAtlas
+    path: 's/UVAtlas'
   - task: DeleteFiles@1
     displayName: Delete files
     inputs:
@@ -123,7 +123,7 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-    path: UVAtlas
+    path: 's/UVAtlas'
   - task: DeleteFiles@1
     displayName: Delete files
     inputs:

--- a/build/UVAtlas-GitHub-Test-Dev17.yml
+++ b/build/UVAtlas-GitHub-Test-Dev17.yml
@@ -28,6 +28,8 @@ jobs:
   displayName: 'Win32 Desktop'
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 1
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true
@@ -115,6 +117,8 @@ jobs:
 - job: CMAKE_BUILD
   displayName: 'CMake BUILD_TESTING=ON'
   timeoutInMinutes: 120
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true

--- a/build/UVAtlas-GitHub-Test.yml
+++ b/build/UVAtlas-GitHub-Test.yml
@@ -48,7 +48,10 @@ jobs:
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 1
   steps:
-  - checkout: none
+  - checkout: self
+    clean: true
+    fetchTags: false
+    path: UVAtlas
   - task: DeleteFiles@1
     displayName: Delete files
     inputs:
@@ -65,7 +68,6 @@ jobs:
       script: |
         git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
         git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
-        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/UVAtlas.git
 
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true

--- a/build/UVAtlas-GitHub-Test.yml
+++ b/build/UVAtlas-GitHub-Test.yml
@@ -54,15 +54,6 @@ jobs:
     clean: true
     fetchTags: false
     path: 's/UVAtlas'
-  - task: DeleteFiles@1
-    displayName: Delete files
-    inputs:
-      Contents: |
-        DirectXTex\**
-        DirectXMesh\**
-        Tests\**
-
-      RemoveDotFiles: true
   - task: CmdLine@2
     displayName: Fetch Libraries
     inputs:
@@ -70,18 +61,18 @@ jobs:
         git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
         git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
 
-      workingDirectory: $(Build.SourcesDirectory)
+      workingDirectory: $(Pipeline.Workspace)/s
       failOnStderr: true
   - task: CmdLine@2
     displayName: Fetch Tests
     inputs:
       script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/uvatlastest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)/UVAtlas
+      workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2019.sln 32dbg
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
+      solution: Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
@@ -89,7 +80,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solutionxtuvatlas_Desktop_2019.sln 32rel
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
+      solution: Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
@@ -97,7 +88,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2019.sln 64dbg
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
+      solution: Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
@@ -105,7 +96,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2019.sln 64rel
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
+      solution: Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
@@ -113,7 +104,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2019.sln arm64dbg
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
+      solution: Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64
@@ -121,7 +112,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2019.sln arm64rel
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
+      solution: Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64

--- a/build/UVAtlas-GitHub-Test.yml
+++ b/build/UVAtlas-GitHub-Test.yml
@@ -53,7 +53,7 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-    path: UVAtlas
+    path: 's/UVAtlas'
   - task: DeleteFiles@1
     displayName: Delete files
     inputs:

--- a/build/UVAtlas-GitHub-Test.yml
+++ b/build/UVAtlas-GitHub-Test.yml
@@ -47,6 +47,8 @@ jobs:
   displayName: 'Win32 Desktop'
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 1
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true
@@ -58,7 +60,6 @@ jobs:
       Contents: |
         DirectXTex\**
         DirectXMesh\**
-        UVAtlas\**
         Tests\**
 
       RemoveDotFiles: true


### PR DESCRIPTION
Some of the changes in #132 removed variable used only for debug build output. This PR restores those variables.