### PR TITLE
Suppress GNU GCC  "-Wstringop-overflow" warnings.

### DIFF
--- a/UVAtlas/isochart/isochartmesh.cpp
+++ b/UVAtlas/isochart/isochartmesh.cpp
@@ -3347,14 +3347,9 @@ HRESULT CIsochartMesh::CalculateDijkstraPathToVertex(
     }
 
     bool* pbVertProcessed = vertProcessed.get();
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif
-    memset(pbVertProcessed, 0, sizeof(bool) * m_dwVertNumber);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+    for(size_t i = 0; i < m_dwVertNumber; ++i) {
+        pbVertProcessed[i] = 0;
+    }
 
     auto pHeapItem = heapItem.get();
 

--- a/UVAtlas/isochart/isochartmesh.cpp
+++ b/UVAtlas/isochart/isochartmesh.cpp
@@ -3347,7 +3347,14 @@ HRESULT CIsochartMesh::CalculateDijkstraPathToVertex(
     }
 
     bool* pbVertProcessed = vertProcessed.get();
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
     memset(pbVertProcessed, 0, sizeof(bool) * m_dwVertNumber);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
     auto pHeapItem = heapItem.get();
 

--- a/UVAtlas/isochart/meshapplyisomap.cpp
+++ b/UVAtlas/isochart/meshapplyisomap.cpp
@@ -562,7 +562,6 @@ HRESULT CIsochartMesh::CalculateGeodesicDistanceToVertexKS98(
     {
         return E_OUTOFMEMORY;
     }
-
     for(size_t i = 0; i < m_dwVertNumber; ++i) {
         pbVertProcessed[i] = 0;
     }

--- a/UVAtlas/isochart/meshapplyisomap.cpp
+++ b/UVAtlas/isochart/meshapplyisomap.cpp
@@ -562,7 +562,14 @@ HRESULT CIsochartMesh::CalculateGeodesicDistanceToVertexKS98(
     {
         return E_OUTOFMEMORY;
     }
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
     memset(pbVertProcessed.get(), 0, sizeof(bool) * m_dwVertNumber);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
     CMaxHeap<float, uint32_t> heap;
     if (!heap.resize(m_dwVertNumber))

--- a/UVAtlas/isochart/meshapplyisomap.cpp
+++ b/UVAtlas/isochart/meshapplyisomap.cpp
@@ -562,14 +562,10 @@ HRESULT CIsochartMesh::CalculateGeodesicDistanceToVertexKS98(
     {
         return E_OUTOFMEMORY;
     }
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif
-    memset(pbVertProcessed.get(), 0, sizeof(bool) * m_dwVertNumber);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+
+    for(size_t i = 0; i < m_dwVertNumber; ++i) {
+        pbVertProcessed[i] = 0;
+    }
 
     CMaxHeap<float, uint32_t> heap;
     if (!heap.resize(m_dwVertNumber))


### PR DESCRIPTION
Addresses issue https://github.com/microsoft/UVAtlas/issues/136 .