### PR TITLE
Workaround clang/LLVM bug with /fp:fast+SSE+float_control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,7 @@ endif()
 
 if(MSVC)
     foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-      target_compile_options(${t} PRIVATE /Wall /GR- /fp:fast "$<$<NOT:$<CONFIG:DEBUG>>:/guard:cf>")
+      target_compile_options(${t} PRIVATE /Wall /GR- "$<$<NOT:$<CONFIG:DEBUG>>:/guard:cf>")
       target_link_options(${t} PRIVATE /DYNAMICBASE /NXCOMPAT /INCREMENTAL:NO)
     endforeach()
 
@@ -388,7 +388,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     endforeach()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-      target_compile_options(${t} PRIVATE /sdl /permissive- /JMC- /Zc:__cplusplus /Zc:inline)
+      target_compile_options(${t} PRIVATE /sdl /permissive- /JMC- /Zc:__cplusplus /Zc:inline /fp:fast)
     endforeach()
 
     if(ENABLE_CODE_ANALYSIS)

--- a/UVAtlas/geodesics/ApproximateOneToAll.cpp
+++ b/UVAtlas/geodesics/ApproximateOneToAll.cpp
@@ -276,6 +276,9 @@ void CApproximateOneToAll::CutHeapTopData(EdgeWindow& EdgeWindowOut)
                         tmpdif = fabs(sigma + SqrtMin0(SquredD2Dist(spie, tmpp)) - tmpDp);
                     }
                     break;
+
+                    default:
+                    break;
                     }
 
                     if (tmpdif > diflargest)

--- a/UVAtlas/isochart/UVAtlasRepacker.cpp
+++ b/UVAtlas/isochart/UVAtlasRepacker.cpp
@@ -1560,6 +1560,8 @@ void CUVAtlasRepacker::GetChartPutPosition(uint32_t index)
         else
             m_chartFromX = m_fromX + m_triedOverlappedLen - pPosInfo->numY;
         break;
+    default:
+        break;
     }
 
     if (m_triedPutRotation == 0 || m_triedPutRotation == 180) {
@@ -1637,6 +1639,8 @@ void CUVAtlasRepacker::PutChartInPosition(uint32_t index)
         transMatrix = XMMatrixTranslation(
             m_PixelWidth * float(m_chartFromX) - pPosInfo->basePoint.x,
             m_PixelWidth * float(m_chartToY) - pPosInfo->basePoint.y, 0.0f);
+        break;
+    default:
         break;
     }
 
@@ -1754,6 +1758,8 @@ void CUVAtlasRepacker::UpdateSpaceInfo(int direction)
             while (j > minY&& m_UVBoard[size_t(--j)][size_t(i)] == 0);
             m_SpaceInfo[UV_DOWNSIDE][size_t(i)] = maxY - j - 1;
         }
+        break;
+    default:
         break;
     }
 


### PR DESCRIPTION
The clang/LLVM toolset currently does not respect the ``float_control`` pragma for SSE instrinsics. Therefore, the use of ``/fp:fast`` is not recommended on clang/LLVM until this issue is fixed. See [55713](https://github.com/llvm/llvm-project/issues/55713).

Also includes updates for warnings found under clang v18.1.0 RC
