### PR TITLE
Add GitHub Action for BVTs with subset of tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -1,0 +1,106 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=512686
+
+name: 'CTest (BVTs)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.mdb
+      - build/*.props
+      - build/*.ps1
+      - build/*.yml
+
+env:
+  DIRECTXMESH_MEDIA_PATH: ${{ github.workspace }}/Media
+  DIRECTXTEX_MEDIA_PATH: ${{ github.workspace }}/Media
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [windows-2019, windows-2022]
+        build_type: [x64-Release]
+        arch: [amd64]
+
+    steps:
+    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+    - name: Clone test repository
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      with:
+        repository: walbourn/uvatlastest
+        path: Tests
+        ref: main
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: 'Set triplet'
+      shell: pwsh
+      run: |
+        if ("${{ matrix.arch }}" -eq "amd64")
+        {
+            echo "VCPKG_DEFAULT_TRIPLET=x64-windows" >> $env:GITHUB_ENV
+        }
+        elseif ("${{ matrix.arch }}" -eq "amd64_x86")
+        {
+            echo "VCPKG_DEFAULT_TRIPLET=x86-windows" >> $env:GITHUB_ENV
+        }
+        elseif ("${{ matrix.arch }}" -eq "amd64_arm64")
+        {
+            if ("${{ matrix.build_type }}" -match "^arm64ec")
+            {
+                echo "VCPKG_DEFAULT_TRIPLET=arm64ec-windows" >> $env:GITHUB_ENV
+            }
+            else
+            {
+                echo "VCPKG_DEFAULT_TRIPLET=arm64-windows" >> $env:GITHUB_ENV
+            }
+        }
+        else
+        {
+            echo "::error Unknown architecture/build-type triplet mapping"
+        }
+
+    - uses: lukka/run-vcpkg@7d259227a1fb6471a0253dd5ab7419835228f7d7 # v11
+      with:
+        runVcpkgInstall: true
+        vcpkgJsonGlob: '**/build/vcpkg.json'
+        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+
+    - name: 'Configure CMake'
+      working-directory: ${{ github.workspace }}
+      shell: pwsh
+      run: >
+        cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON -DBUILD_TOOLS=OFF -DBUILD_BVT=ON
+        -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_MANIFEST_DIR="${{ github.workspace }}/build"
+        -DVCPKG_TARGET_TRIPLET="${env:VCPKG_DEFAULT_TRIPLET}"
+
+    - name: 'Build'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}
+
+    - name: 'Run BVTs'
+      working-directory: ${{ github.workspace }}
+      run: ctest --preset=${{ matrix.build_type }} --output-on-failure

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -83,7 +83,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
+        vcpkgGitCommitId: '${{ vars.VCPKG_COMMIT_ID }}'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -83,7 +83,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=512686
+# https://go.microsoft.com/fwlink/?LinkID=512686
 
 name: 'CTest (BVTs)'
 

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -19,10 +19,6 @@ on:
       - build/*.ps1
       - build/*.yml
 
-env:
-  DIRECTXMESH_MEDIA_PATH: ${{ github.workspace }}/Media
-  DIRECTXTEX_MEDIA_PATH: ${{ github.workspace }}/Media
-
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
+        vcpkgGitCommitId: '${{ vars.VCPKG_COMMIT_ID }}'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=512686
+# https://go.microsoft.com/fwlink/?LinkID=512686
 
 name: 'CTest (Windows)'
 

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -83,7 +83,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
+        vcpkgGitCommitId: '${{ vars.VCPKG_COMMIT_ID }}'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -83,7 +83,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=512686
+# https://go.microsoft.com/fwlink/?LinkID=512686
 
 name: 'CMake (Windows using VCPKG)'
 

--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
+        vcpkgGitCommitId: '${{ vars.VCPKG_COMMIT_ID }}'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=512686
+# https://go.microsoft.com/fwlink/?LinkID=512686
 
 name: 'CMake (WSL)'
 

--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/build/UVAtlas-GitHub-MinGW.yml
+++ b/build/UVAtlas-GitHub-MinGW.yml
@@ -116,12 +116,13 @@ jobs:
         Write-Host "Added to path: $env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
         Write-Host "##vso[task.prependpath]$env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
         $sdkroot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' | Select-Object -ExpandProperty KitsRoot10
-        $windows11sdk = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
-        if (Test-Path "$windows11sdk") {
-            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$windows11sdk"
-        }
-        else {
-            Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop
+        $wsdkbin = "{0}bin\" -f $sdkroot
+        $wsdkverbin = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
+        $wsdkarchbin = "{0}bin\$(WIN11_SDK)\x86" -f $sdkroot
+        if (Test-Path "$wsdkarchbin") {
+            Write-Host "##vso[task.setvariable variable=WindowsSdkBinPath;]$wsdkbin"
+            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$wsdkverbin"
+            Write-Host "##vso[task.prependpath]$wsdkarchbin"
         }
 
       workingDirectory: $(Build.SourcesDirectory)
@@ -184,11 +185,13 @@ jobs:
       script: |
         $ProgressPreference = 'SilentlyContinue'
         $sdkroot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' | Select-Object -ExpandProperty KitsRoot10
-        $windows11sdk = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
-        $windows11x64sdk = "{0}bin\$(WIN11_SDK)\x64" -f $sdkroot
-        if (Test-Path "$windows11sdk") {
-            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$windows11sdk"
-            Write-Host "##vso[task.prependpath]$windows11x64sdk"
+        $wsdkbin = "{0}bin\" -f $sdkroot
+        $wsdkverbin = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
+        $wsdkarchbin = "{0}bin\$(WIN11_SDK)\x64" -f $sdkroot
+        if (Test-Path "$wsdkarchbin") {
+            Write-Host "##vso[task.setvariable variable=WindowsSdkBinPath;]$wsdkbin"
+            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$wsdkverbin"
+            Write-Host "##vso[task.prependpath]$wsdkarchbin"
         }
         else {
             Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop

--- a/build/UVAtlas-GitHub-MinGW.yml
+++ b/build/UVAtlas-GitHub-MinGW.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=512686
+# https://go.microsoft.com/fwlink/?LinkID=512686
 
 # Builds the library and test suite using the MinGW compiler.
 
@@ -22,7 +22,6 @@ trigger:
     - LICENSE
     - '.github/*'
     - '.nuget/*'
-    - build/*.json
     - build/*.props
     - build/*.mdb
     - build/*.ps1
@@ -37,7 +36,6 @@ pr:
     - LICENSE
     - '.github/*'
     - '.nuget/*'
-    - build/*.json
     - build/*.props
     - build/*.mdb
     - build/*.ps1
@@ -48,6 +46,16 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
+  - repository: testRepo
+    name: walbourn/uvatlastest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -56,8 +64,9 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
   WIN11_SDK: '10.0.22000.0'
   URL_MINGW32: https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-14.0.6-10.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-12.2.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r2.zip
   HASH_MINGW32: 'fcd1e11b896190da01c83d5b5fb0d37b7c61585e53446c2dab0009debc3915e757213882c35e35396329338de6f0222ba012e23a5af86932db45186a225d1272'
@@ -69,12 +78,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
-    # We can use the preinstalled vcpkg instead of the latest when MS Hosted updates their vcpkg to the newer DirectX-Headers
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
@@ -119,30 +130,22 @@ jobs:
     inputs:
       script: g++ --version
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: |
-        call vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x86-mingw-static
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake (MinGW32)
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out
 
 - job: MINGW64_BUILD
@@ -151,15 +154,20 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
-  - task: CmdLine@2
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/uvatlastest.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
@@ -191,32 +199,20 @@ jobs:
     inputs:
       script: g++ --version
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: |
-        call vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directxmesh
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directxtex
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-mingw-static
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake (MinGW-W64)
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"  -DVCPKG_TARGET_TRIPLET=x64-mingw-static
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out

--- a/build/UVAtlas-GitHub-MinGW.yml
+++ b/build/UVAtlas-GitHub-MinGW.yml
@@ -124,6 +124,9 @@ jobs:
             Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$wsdkverbin"
             Write-Host "##vso[task.prependpath]$wsdkarchbin"
         }
+        else {
+            Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop
+        }
 
       workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2

--- a/build/UVAtlas-GitHub-Test-Dev17.yml
+++ b/build/UVAtlas-GitHub-Test-Dev17.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=512686
+# https://go.microsoft.com/fwlink/?LinkID=512686
 
 # Builds the library and test suite.
 
@@ -22,6 +22,27 @@ pr:
     include:
     - build/UVAtlas-GitHub-Test-Dev17.yml
 
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: refs/heads/main
+  - repository: dxMeshRepo
+    name: Microsoft/DirectXMesh
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: dxTexRepo
+    name: Microsoft/DirectXTex
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/uvatlastest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
@@ -30,7 +51,6 @@ pool:
 variables:
   Codeql.Enabled: false
   VC_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 jobs:
 - job: DESKTOP_BUILD
@@ -44,25 +64,28 @@ jobs:
     clean: true
     fetchTags: false
     path: 's/UVAtlas'
-  - task: CmdLine@2
-    displayName: Fetch Libraries
-    inputs:
-      script: |
-        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
-        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
-
-      workingDirectory: $(Pipeline.Workspace)/s
-      failOnStderr: true
-  - task: CmdLine@2
+  - checkout: dxMeshRepo
+    displayName: Fetch DirectXMesh
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/DirectXMesh'
+  - checkout: dxTexRepo
+    displayName: Fetch DirectXTex
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/DirectXTex'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/uvatlastest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/UVAtlas/Tests'
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2022.sln 32dbg
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2022.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
@@ -71,7 +94,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solutionxtuvatlas_Desktop_2022.sln 32rel
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2022.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
@@ -80,7 +103,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2022.sln 64dbg
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2022.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
@@ -89,7 +112,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2022.sln 64rel
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2022.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
@@ -98,7 +121,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2022.sln arm64dbg
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2022.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64
@@ -107,7 +130,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2022.sln arm64rel
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2022.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64
@@ -124,21 +147,24 @@ jobs:
     clean: true
     fetchTags: false
     path: 's/UVAtlas'
-  - task: CmdLine@2
-    displayName: Fetch Libraries
-    inputs:
-      script: |
-        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
-        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
-
-      workingDirectory: $(Pipeline.Workspace)/s
-      failOnStderr: true
-  - task: CmdLine@2
+  - checkout: dxMeshRepo
+    displayName: Fetch DirectXMesh
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/DirectXMesh'
+  - checkout: dxTexRepo
+    displayName: Fetch DirectXTex
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/DirectXTex'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/uvatlastest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/UVAtlas/Tests'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:
@@ -157,12 +183,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; x64-Debug) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --preset=x64-Debug
   - task: CMake@1
     displayName: CMake (MSVC; x64-Debug) Build
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --build out/build/x64-Debug -v
   - task: DeleteFiles@1
     inputs:
@@ -170,12 +196,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; x64-Release) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --preset=x64-Release
   - task: CMake@1
     displayName: CMake (MSVC; x64-Release) Build
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --build out/build/x64-Release -v
   - task: DeleteFiles@1
     inputs:
@@ -183,12 +209,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Debug) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --preset=x64-Debug-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Debug) Build
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --build out/build/x64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -196,12 +222,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Release) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --preset=x64-Release-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Release) Build
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --build out/build/x64-Release-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -216,12 +242,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Debug) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --preset=arm64-Debug-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Debug) Build
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --build out/build/arm64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -229,12 +255,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Release) Config
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --preset=arm64-Release-Clang
   - task: CMake@1
     # This is disabled to avoid an ICE with clang v15.0.1
     displayName: CMake (clang/LLVM; arm64-Release) Build
     enabled: false
     inputs:
-      cwd: $(Build.SourcesDirectory)
+      cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --build out/build/arm64-Release-Clang -v

--- a/build/UVAtlas-GitHub-Test.yml
+++ b/build/UVAtlas-GitHub-Test.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=512686
+# https://go.microsoft.com/fwlink/?LinkID=512686
 
 # Builds the library and test suite.
 
@@ -22,6 +22,27 @@ pr:
     include:
     - build/UVAtlas-GitHub-Test.yml
 
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: refs/heads/main
+  - repository: dxMeshRepo
+    name: Microsoft/DirectXMesh
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: dxTexRepo
+    name: Microsoft/DirectXTex
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/uvatlastest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
@@ -29,7 +50,6 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 jobs:
 - job: DESKTOP_BUILD
@@ -43,25 +63,28 @@ jobs:
     clean: true
     fetchTags: false
     path: 's/UVAtlas'
-  - task: CmdLine@2
-    displayName: Fetch Libraries
-    inputs:
-      script: |
-        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMesh.git
-        git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXTex.git
-
-      workingDirectory: $(Pipeline.Workspace)/s
-      failOnStderr: true
-  - task: CmdLine@2
+  - checkout: dxMeshRepo
+    displayName: Fetch DirectXMesh
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/DirectXMesh'
+  - checkout: dxTexRepo
+    displayName: Fetch DirectXTex
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/DirectXTex'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/uvatlastest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/UVAtlas/Tests'
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2019.sln 32dbg
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2019.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
@@ -69,7 +92,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solutionxtuvatlas_Desktop_2019.sln 32rel
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2019.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
@@ -77,7 +100,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2019.sln 64dbg
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2019.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
@@ -85,7 +108,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2019.sln 64rel
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2019.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
@@ -93,7 +116,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2019.sln arm64dbg
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2019.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64
@@ -101,7 +124,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build solution xtuvatlas_Desktop_2019.sln arm64rel
     inputs:
-      solution: Tests/xtuvatlas_Desktop_2019.sln
+      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64

--- a/build/UVAtlas-GitHub-WSL-11.yml
+++ b/build/UVAtlas-GitHub-WSL-11.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=512686
+# https://go.microsoft.com/fwlink/?LinkID=512686
 
 # Builds the library for Windows Subsystem for Linux (WSL)
 
@@ -32,6 +32,21 @@ resources:
     type: git
     ref: refs/heads/main
     trigger: none
+  - repository: dxHeadersRepo
+    name: Microsoft/DirectX-Headers
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: dxMathRepo
+    name: Microsoft/DirectXMath
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -40,9 +55,9 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  VCPKG_ROOT: '$(Build.SourcesDirectory)/vcpkg'
-  VCPKG_CMAKE_DIR: '$(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
   LOCAL_PKG_DIR: '$(Agent.BuildDirectory)/install/'
 
 jobs:
@@ -54,10 +69,20 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
-    displayName: Fetch directx-headers
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectX-Headers.git directx-headers
+    fetchDepth: 1
+    path: 's'
+  - checkout: dxHeadersRepo
+    displayName: Fetch DirectX-Headers
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directx-headers'
+  - checkout: dxMathRepo
+    displayName: Fetch DirectX-Math
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directxmath'
   - task: CMake@1
     displayName: CMake DirectX-Headers
     inputs:
@@ -73,10 +98,6 @@ jobs:
     inputs:
       cwd: directx-headers
       cmakeArgs: --install .
-  - task: CmdLine@2
-    displayName: Fetch directxmath
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMath.git directxmath
   - task: CMake@1
     displayName: CMake DirectXMath
     inputs:
@@ -109,22 +130,22 @@ jobs:
   - task: CMake@1
     displayName: CMake UVAtlas (Config) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake UVAtlas (Build) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v
   - task: CMake@1
     displayName: CMake UVAtlas (Config) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake UVAtlas (Build) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v
 
 - job: BUILD_WSL_VCPKG
@@ -135,11 +156,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - task: Bash@3
     displayName: VCPKG Bootstrap
     inputs:
@@ -154,37 +178,43 @@ jobs:
         cmake --version
 
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: $(Build.SourcesDirectory)/vcpkg/vcpkg install --x-manifest-root=$(Build.SourcesDirectory)/build
-      workingDirectory: $(Build.SourcesDirectory)/vcpkg
+      script: vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-linux
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake UVAtlas (Config) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR=$(Build.SourcesDirectory)/build
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE=Debug -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake UVAtlas (Build) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v
   - task: CMake@1
     displayName: CMake UVAtlas (Config) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR=$(Build.SourcesDirectory)/build
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out2 -DCMAKE_BUILD_TYPE=Release -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake UVAtlas (Build) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v
   - task: CMake@1
     displayName: CMake UVAtlas (Config) w/ Eigen
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE=Debug -DENABLE_USE_EIGEN=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR=$(Build.SourcesDirectory)/build
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out3 -DCMAKE_BUILD_TYPE=Debug -DENABLE_USE_EIGEN=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake UVAtlas (Build) w/ Eigen
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3 -v

--- a/build/UVAtlas-GitHub-WSL.yml
+++ b/build/UVAtlas-GitHub-WSL.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=512686
+# https://go.microsoft.com/fwlink/?LinkID=512686
 
 # Builds the library for Windows Subsystem for Linux (WSL)
 
@@ -46,6 +46,21 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: dxHeadersRepo
+    name: Microsoft/DirectX-Headers
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: dxMathRepo
+    name: Microsoft/DirectXMath
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -54,9 +69,9 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  VCPKG_ROOT: '$(Build.SourcesDirectory)/vcpkg'
-  VCPKG_CMAKE_DIR: '$(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
   LOCAL_PKG_DIR: '$(Agent.BuildDirectory)/install/'
 
 jobs:
@@ -68,10 +83,20 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
-    displayName: Fetch directx-headers
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectX-Headers.git directx-headers
+    fetchDepth: 1
+    path: 's'
+  - checkout: dxHeadersRepo
+    displayName: Fetch DirectX-Headers
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directx-headers'
+  - checkout: dxMathRepo
+    displayName: Fetch DirectX-Math
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directxmath'
   - task: CMake@1
     displayName: CMake DirectX-Headers
     inputs:
@@ -87,10 +112,6 @@ jobs:
     inputs:
       cwd: directx-headers
       cmakeArgs: --install .
-  - task: CmdLine@2
-    displayName: Fetch directxmath
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMath.git directxmath
   - task: CMake@1
     displayName: CMake DirectXMath
     inputs:
@@ -123,22 +144,22 @@ jobs:
   - task: CMake@1
     displayName: CMake UVAtlas (Config) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake UVAtlas (Build) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v
   - task: CMake@1
     displayName: CMake UVAtlas (Config) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake UVAtlas (Build) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v
 
 - job: BUILD_WSL_VCPKG
@@ -149,11 +170,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - task: Bash@3
     displayName: VCPKG Bootstrap
     inputs:
@@ -168,37 +192,43 @@ jobs:
         cmake --version
 
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: $(Build.SourcesDirectory)/vcpkg/vcpkg install --x-manifest-root=$(Build.SourcesDirectory)/build
-      workingDirectory: $(Build.SourcesDirectory)/vcpkg
+      script: vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-linux
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake UVAtlas (Config) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR=$(Build.SourcesDirectory)/build
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE=Debug -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake UVAtlas (Build) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v
   - task: CMake@1
     displayName: CMake UVAtlas (Config) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR=$(Build.SourcesDirectory)/build
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out2 -DCMAKE_BUILD_TYPE=Release -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake UVAtlas (Build) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v
   - task: CMake@1
     displayName: CMake UVAtlas (Config) w/ Eigen
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE=Debug -DENABLE_USE_EIGEN=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR=$(Build.SourcesDirectory)/build
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out3 -DCMAKE_BUILD_TYPE=Debug -DENABLE_USE_EIGEN=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake UVAtlas (Build) w/ Eigen
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3 -v

--- a/build/UVAtlas-SDL.yml
+++ b/build/UVAtlas-SDL.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkID=512686
+# https://go.microsoft.com/fwlink/?LinkID=512686
 
 # Runs various SDL recommended tools on the code.
 
@@ -27,6 +27,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -36,10 +41,9 @@ variables:
   Codeql.ExcludePathPatterns: vcpkg
   VC_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC'
   VS_GENERATOR: 'Visual Studio 17 2022'
-  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
-  URL_FEED: $(ADOFeedURL)
-  skipNugetSecurityAnalysis: true # We explicitly call this task so we don't need it to be auto-injected
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
 
 pool:
   vmImage: windows-2022
@@ -53,28 +57,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: PowerShell@2
-    displayName: 'Create nuget.config with single source'
-    inputs:
-      targetType: inline
-      script: |
-        $xml = @'
-        <?xml version="1.0" encoding="utf-8"?>
-        <configuration>
-          <packageSources>
-            <clear />
-          </packageSources>
-        </configuration>
-        '@
-        $xml | Set-Content -Path "$(Build.SourcesDirectory)\NuGet.config"
-
-  - task: NuGetCommand@2
-    displayName: 'NuGet set package source to ADO feed'
-    inputs:
-      command: custom
-      arguments: sources add -Name xboxgdk -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
-  - task: nuget-security-analysis@0
-    displayName: 'Secure Supply Chain Analysis'
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
+    displayName: Fetch VCPKG
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - task: NodeTool@0
     displayName: 'NPM install'
     inputs:
@@ -93,43 +83,17 @@ jobs:
   - task: Armory@2
     displayName: Run ARMory
   - task: CmdLine@2
-    # We can use the preinstalled vcpkg instead of the latest when MS Hosted updates their vcpkg to the newer DirectX-Headers
-    displayName: Fetch VCPKG
+    displayName: VCPKG install packages
     inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
-  - task: CmdLine@2
-    displayName: VCPKG Bootstrap
-    inputs:
-      script: |
-        call bootstrap-vcpkg.bat
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
-  - task: CmdLine@2
-    displayName: VCPKG install headers
-    inputs:
-      script: |
-        call vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directxmesh[spectre]
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directxtex[spectre]
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out -DENABLE_SPECTRE_MITIGATION=ON -DBUILD_TOOLS=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A x64 -B out -DENABLE_SPECTRE_MITIGATION=ON -DBUILD_TOOLS=ON
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CodeQL3000Init@0
     inputs:
       Enabled: true
@@ -146,7 +110,7 @@ jobs:
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v --config RelWithDebInfo
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@4
     displayName: 'Run AntiMalware'
@@ -183,6 +147,7 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
+    fetchDepth: 1
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:
@@ -201,10 +166,10 @@ jobs:
   - task: CMake@1
     displayName: CMake Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Debug -DENABLE_CODE_ANALYSIS=ON
   - task: CMake@1
     displayName: CMake Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Debug

--- a/build/UVAtlas-SDL.yml
+++ b/build/UVAtlas-SDL.yml
@@ -11,6 +11,7 @@ schedules:
   branches:
     include:
     - main
+  always: true
 
 # GitHub Actions handles CodeQL and PREFAST for CI/PR
 trigger: none


### PR DESCRIPTION
This builds the test suite such that it only needs a few test data files which are included directly in the test repo. This avoids LFS bandwidth traffic for the full set of test data.

> Includes ADO YAML code review to clean up use of PATs, and to convert all use of vcpkg in the pipelines to 'manifest mode'.

> Also sets the dependabot to not spam quite so often for GHA.