### PR TITLE
CMake code review feedback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,13 +147,13 @@ endif()
 
 if(directxmath_FOUND)
     message(STATUS "Using DirectXMath package")
-    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Microsoft::DirectXMath)
 endif()
 
 if(directx-headers_FOUND)
     message(STATUS "Using DirectX-Headers package")
-    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC USING_DIRECTX_HEADERS)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Microsoft::DirectX-Headers)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE USING_DIRECTX_HEADERS)
 endif()
 
 if(ENABLE_USE_EIGEN)

--- a/UVAtlasTool/UVAtlas.cpp
+++ b/UVAtlasTool/UVAtlas.cpp
@@ -1072,7 +1072,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             hr = inMesh->ComputeNormals(flags);
             if (FAILED(hr))
             {
-                wprintf(L"\nERROR: Failed computing normals (flags:%X, %08X%ls)\n", flags,
+                wprintf(L"\nERROR: Failed computing normals (flags:%X, %08X%ls)\n", static_cast<unsigned int>(flags),
                     static_cast<unsigned int>(hr), GetErrorDesc(hr));
                 return 1;
             }

--- a/UVAtlasTool/UVAtlas.cpp
+++ b/UVAtlasTool/UVAtlas.cpp
@@ -1072,7 +1072,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             hr = inMesh->ComputeNormals(flags);
             if (FAILED(hr))
             {
-                wprintf(L"\nERROR: Failed computing normals (flags:%lX, %08X%ls)\n", flags,
+                wprintf(L"\nERROR: Failed computing normals (flags:%X, %08X%ls)\n", flags,
                     static_cast<unsigned int>(hr), GetErrorDesc(hr));
                 return 1;
             }


### PR DESCRIPTION
Minor tweak to CMake to avoid requiring all clients use directxmath and directx-headers packages externally.

> Also fix /analyze warning
