### PR TITLE
Code review for const auto vs auto const

### DIFF
--- a/UVAtlas/isochart/SymmetricMatrix.hpp
+++ b/UVAtlas/isochart/SymmetricMatrix.hpp
@@ -63,7 +63,7 @@ namespace Isochart
                         static_cast<int>(std::min(dwMaxRange * 2, dwDimension))
                     );
                     eigs.init();
-                    auto const numConverged = eigs.compute(
+                    const auto numConverged = eigs.compute(
                         Spectra::SortRule::LargestAlge,  // Sort by descending eigenvalues.
                         maxIterations,
                         epsilon

--- a/UVAtlasTool/Mesh.cpp
+++ b/UVAtlasTool/Mesh.cpp
@@ -75,7 +75,7 @@ namespace
 
         if (length > 0)
         {
-            auto const bytes = static_cast<DWORD>(sizeof(wchar_t) * length);
+            const auto bytes = static_cast<DWORD>(sizeof(wchar_t) * length);
 
             if (!WriteFile(hFile, value, bytes, &bytesWritten, nullptr))
                 return HRESULT_FROM_WIN32(GetLastError());
@@ -1323,7 +1323,7 @@ HRESULT Mesh::ExportToVBO(const wchar_t* szFileName) const noexcept
     if (FAILED(hr))
         return hr;
 
-    auto const vertSize = static_cast<DWORD>(sizeof(vertex_t) * header.numVertices);
+    const auto vertSize = static_cast<DWORD>(sizeof(vertex_t) * header.numVertices);
 
     DWORD bytesWritten;
     if (!WriteFile(hFile.get(), vb.get(), vertSize, &bytesWritten, nullptr))
@@ -1332,7 +1332,7 @@ HRESULT Mesh::ExportToVBO(const wchar_t* szFileName) const noexcept
     if (bytesWritten != vertSize)
         return E_FAIL;
 
-    auto const indexSize = static_cast<DWORD>(sizeof(uint16_t) * header.numIndices);
+    const auto indexSize = static_cast<DWORD>(sizeof(uint16_t) * header.numIndices);
 
     if (!WriteFile(hFile.get(), ib.get(), indexSize, &bytesWritten, nullptr))
         return HRESULT_FROM_WIN32(GetLastError());
@@ -1404,7 +1404,7 @@ HRESULT Mesh::CreateFromVBO(const wchar_t* szFileName, std::unique_ptr<Mesh>& re
     if (!vb || !ib)
         return E_OUTOFMEMORY;
 
-    auto const vertSize = static_cast<DWORD>(sizeof(vertex_t) * header.numVertices);
+    const auto vertSize = static_cast<DWORD>(sizeof(vertex_t) * header.numVertices);
 
     if (!ReadFile(hFile.get(), vb.get(), vertSize, &bytesRead, nullptr))
     {
@@ -1414,7 +1414,7 @@ HRESULT Mesh::CreateFromVBO(const wchar_t* szFileName, std::unique_ptr<Mesh>& re
     if (bytesRead != vertSize)
         return E_FAIL;
 
-    auto const indexSize = static_cast<DWORD>(sizeof(uint16_t) * header.numIndices);
+    const auto indexSize = static_cast<DWORD>(sizeof(uint16_t) * header.numIndices);
 
     if (!ReadFile(hFile.get(), ib.get(), indexSize, &bytesRead, nullptr))
     {
@@ -1899,7 +1899,7 @@ HRESULT Mesh::ExportToCMO(const wchar_t* szFileName, size_t nMaterials, const Ma
     if (FAILED(hr))
         return hr;
 
-    auto const indexSize = static_cast<DWORD>(sizeof(uint16_t) * nIndices);
+    const auto indexSize = static_cast<DWORD>(sizeof(uint16_t) * nIndices);
 
     DWORD bytesWritten;
     if (!WriteFile(hFile.get(), ib.get(), indexSize, &bytesWritten, nullptr))
@@ -1919,7 +1919,7 @@ HRESULT Mesh::ExportToCMO(const wchar_t* szFileName, size_t nMaterials, const Ma
     if (FAILED(hr))
         return hr;
 
-    auto const vertSize = static_cast<DWORD>(sizeof(Vertex) * mnVerts);
+    const auto vertSize = static_cast<DWORD>(sizeof(Vertex) * mnVerts);
 
     if (!WriteFile(hFile.get(), vb.get(), vertSize, &bytesWritten, nullptr))
         return HRESULT_FROM_WIN32(GetLastError());
@@ -1940,7 +1940,7 @@ HRESULT Mesh::ExportToCMO(const wchar_t* szFileName, size_t nMaterials, const Ma
         if (FAILED(hr))
             return hr;
 
-        auto const skinVertSize = static_cast<DWORD>(sizeof(SkinningVertex) * mnVerts);
+        const auto skinVertSize = static_cast<DWORD>(sizeof(SkinningVertex) * mnVerts);
 
         if (!WriteFile(hFile.get(), vbSkin.get(), skinVertSize, &bytesWritten, nullptr))
             return HRESULT_FROM_WIN32(GetLastError());

--- a/UVAtlasTool/UVAtlas.cpp
+++ b/UVAtlasTool/UVAtlas.cpp
@@ -903,7 +903,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
     for (auto pConv = conversion.begin(); pConv != conversion.end(); ++pConv)
     {
         std::filesystem::path curpath(pConv->szSrc);
-        auto const ext = curpath.extension();
+        const auto ext = curpath.extension();
 
         if (pConv != conversion.begin())
             wprintf(L"\n");
@@ -1109,7 +1109,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 }
 
                 std::filesystem::path tname(texFile);
-                auto const txext = tname.extension();
+                const auto txext = tname.extension();
 
                 ScratchImage iimage;
 
@@ -1540,7 +1540,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 
                 os.imbue(std::locale::classic());
 
-                for (auto const& mtl : inMaterial)
+                for (const auto& mtl : inMaterial)
                 {
                     // Minimal material output.
                     os << L"newmtl " << mtl.name << std::endl;

--- a/build/UVAtlas-GitHub-WSL-13.yml
+++ b/build/UVAtlas-GitHub-WSL-13.yml
@@ -24,7 +24,7 @@ pr:
     - build/*.cmake
     - build/*.in
     - build/vcpkg.json
-    - build/UVAtlas-GitHub-WSL-11.yml
+    - build/UVAtlas-GitHub-WSL-13.yml
 
 resources:
   repositories:


### PR DESCRIPTION
Both ``const auto`` and ``auto const`` are equivalent in terms of the C++ compiler parser, but general coding guidelines suggest using ``const auto``. The primary reason for this PR is to be consistent since the codebase was using both.