### PR TITLE
Add option to build as shared lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ project (UVAtlas
 # Note to support Windows 8.1, turn off BUILD_DX12 build options for both libraries.
 option(BUILD_TOOLS "Build UVAtlasTool" OFF)
 
+option(BUILD_SHARED_LIBS "Build UVAtlas as a shared library" OFF)
+
 # Enable the use of OpenMP
 option(UVATLAS_USE_OPENMP "Build with OpenMP support" ON)
 
@@ -109,7 +111,20 @@ set(LIBRARY_SOURCES
     UVAtlas/isochart/Vis_Maxflow.h
 )
 
-add_library (${PROJECT_NAME} STATIC ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
+if(WIN32 AND BUILD_SHARED_LIBS)
+  message(STATUS "Build library as a DLL")
+
+  configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/build/UVAtlas.rc.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/UVAtlas.rc" @ONLY)
+
+  add_library(${PROJECT_NAME} SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS} "${CMAKE_CURRENT_BINARY_DIR}/UVAtlas.rc")
+
+  target_compile_definitions(${PROJECT_NAME} PRIVATE UVATLAS_EXPORT)
+  target_compile_definitions(${PROJECT_NAME} INTERFACE UVATLAS_IMPORT)
+else()
+  add_library (${PROJECT_NAME} ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
+endif()
 
 source_group(inc REGULAR_EXPRESSION UVAtlas/inc/*.*)
 source_group(geodesics REGULAR_EXPRESSION UVAtlas/geodesics/*.*)

--- a/UVAtlas/inc/UVAtlas.h
+++ b/UVAtlas/inc/UVAtlas.h
@@ -44,6 +44,14 @@
 
 #define UVATLAS_VERSION 189
 
+#ifdef UVATLAS_EXPORT
+#define UVATLAS_API __declspec(dllexport)
+#elif UVATLAS_IMPORT
+#define UVATLAS_API __declspec(dllimport)
+#else
+#define UVATLAS_API
+#endif
+
 
 namespace DirectX
 {
@@ -146,7 +154,7 @@ namespace DirectX
     //                 maximum number of charts was too low, this gives the minimum
     //                 number of charts needed to create an atlas.
 
-    HRESULT __cdecl UVAtlasCreate(
+    UVATLAS_API HRESULT __cdecl UVAtlasCreate(
         _In_reads_(nVerts)                  const XMFLOAT3* positions,
         _In_                                size_t nVerts,
         _When_(indexFormat == DXGI_FORMAT_R16_UINT, _In_reads_bytes_(nFaces * 3 * sizeof(uint16_t)))
@@ -195,7 +203,7 @@ namespace DirectX
     // |_____|
     //
 
-    HRESULT __cdecl UVAtlasPartition(
+    UVATLAS_API HRESULT __cdecl UVAtlasPartition(
         _In_reads_(nVerts)          const XMFLOAT3* positions,
         _In_                        size_t nVerts,
         _When_(indexFormat == DXGI_FORMAT_R16_UINT, _In_reads_bytes_(nFaces * 3 * sizeof(uint16_t)))
@@ -221,7 +229,7 @@ namespace DirectX
     // This takes the face partitioning result from Partition and packs it into an
     // atlas of the given size. pPartitionResultAdjacency should be derived from
     // the adjacency returned from the partition step.
-    HRESULT __cdecl UVAtlasPack(
+    UVATLAS_API HRESULT __cdecl UVAtlasPack(
         _Inout_                 std::vector<UVAtlasVertex>& vMeshVertexBuffer,
         _Inout_                 std::vector<uint8_t>& vMeshIndexBuffer,
         _In_                    DXGI_FORMAT indexFormat,
@@ -261,7 +269,7 @@ namespace DirectX
     //                    a multiple of sizeof(float)
     // pIMTArray        - An array of 3 * nFaces floats for the result
 
-    HRESULT __cdecl UVAtlasComputeIMTFromPerVertexSignal(
+    UVATLAS_API HRESULT __cdecl UVAtlasComputeIMTFromPerVertexSignal(
         _In_reads_(nVerts)                  const XMFLOAT3* positions,
         _In_                                size_t nVerts,
         _When_(indexFormat == DXGI_FORMAT_R16_UINT, _In_reads_bytes_(nFaces * 3 * sizeof(uint16_t)))
@@ -291,7 +299,7 @@ namespace DirectX
     //                   signalOut - A pointer to where to store the signal data.
     // userData        - A pointer that will be passed in to the callback.
     // pIMTArray        - An array of 3 * nFaces floats for the result
-    HRESULT __cdecl UVAtlasComputeIMTFromSignal(
+    UVATLAS_API HRESULT __cdecl UVAtlasComputeIMTFromSignal(
         _In_reads_(nVerts)                  const XMFLOAT3* positions,
         _In_reads_(nVerts)                  const XMFLOAT2* texcoords,
         _In_                                size_t nVerts,
@@ -316,7 +324,7 @@ namespace DirectX
     // pTexture         - The texture to load data from (4 floats per texel)
     // options          - Combination of one or more UVATLAS_IMT flags.
     // pIMTArray        - An array of 3 * nFaces floats for the result
-    HRESULT __cdecl UVAtlasComputeIMTFromTexture(
+    UVATLAS_API HRESULT __cdecl UVAtlasComputeIMTFromTexture(
         _In_reads_(nVerts)                  const XMFLOAT3* positions,
         _In_reads_(nVerts)                  const XMFLOAT2* texcoords,
         _In_                                size_t nVerts,
@@ -341,7 +349,7 @@ namespace DirectX
     // nComponents      - The number of floats in each texel
     // options          - Combination of one or more UVATLAS_IMT flags
     // pIMTArray        - An array of 3 * nFaces floats for the result
-    HRESULT __cdecl UVAtlasComputeIMTFromPerTexelSignal(
+    UVATLAS_API HRESULT __cdecl UVAtlasComputeIMTFromPerTexelSignal(
         _In_reads_(nVerts)                      const XMFLOAT3* positions,
         _In_reads_(nVerts)                      const XMFLOAT2* texcoords,
         _In_                                    size_t nVerts,
@@ -363,7 +371,7 @@ namespace DirectX
     // vbin         - This is the original vertex buffer and is nVerts*stride in size
     // vbout        - This is the output vertex buffer and is nNewVerts*stride in size
     // nNewVerts    - This should be >= nVerts
-    HRESULT __cdecl UVAtlasApplyRemap(
+    UVATLAS_API HRESULT __cdecl UVAtlasApplyRemap(
         _In_reads_bytes_(nVerts* stride)        const void* vbin,
         _In_                                    size_t stride,
         _In_                                    size_t nVerts,

--- a/build/UVAtlas.rc.in
+++ b/build/UVAtlas.rc.in
@@ -1,0 +1,34 @@
+#include <winres.h>
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,0,0,0
+ PRODUCTVERSION @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,0
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "Microsoft Corp"
+            VALUE "FileDescription", "UVAtlas isochart texture atlas"
+            VALUE "FileVersion", "1.0.0.0"
+            VALUE "InternalName", "uvatlas.dll"
+            VALUE "LegalCopyright", "Copyright (c) Microsoft Corp."
+            VALUE "OriginalFilename", "uvatlas.dll"
+            VALUE "ProductName", "UVAtlas"
+            VALUE "ProductVersion", "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/build/versioninfo.ps1
+++ b/build/versioninfo.ps1
@@ -6,7 +6,6 @@ Licensed under the MIT License.
 param(
 [string]$version
 )
-$file = 'UVAtlasTool\uvatlas.rc'
 $versionComma = $version.Replace(".", ",")
-(Get-Content $file).replace('1,0,0,0', $versionComma).replace('1.0.0.0', $version) | Set-Content $file
-(Get-Content $file)
+$files = 'UVAtlasTool\uvatlas.rc', 'build\UVAtlas.rc.in'
+foreach ($file in $files) { (Get-Content $file).replace('1,0,0,0', $versionComma).replace('1.0.0.0', $version) | Set-Content $file }


### PR DESCRIPTION
Uses `BUILD_SHARED_LIBS` standard CMake option to build as a DLL/so vs. a static C++ library.