### PR TITLE
Update ADO coverage for clang v12

### DIFF
--- a/build/UVAtlas-GitHub-CMake.yml
+++ b/build/UVAtlas-GitHub-CMake.yml
@@ -98,82 +98,42 @@ jobs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out2 -v --config RelWithDebInfo
   - task: CMake@1
-    displayName: 'CMake (MSVC): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
-  - task: CMake@1
-    displayName: 'CMake (MSVC): Build ARM64 Debug'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out3 -v --config Debug
-  - task: CMake@1
-    displayName: 'CMake (MSVC): Build ARM64 Release'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out3 -v --config RelWithDebInfo
-  - task: CMake@1
     displayName: 'CMake (UWP): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out3 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0'
   - task: CMake@1
     displayName: 'CMake (UWP): Build x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out4 -v
+      cmakeArgs: --build out3 -v
   - task: CMake@1
     displayName: 'CMake (ClangCl): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -T clangcl -B out6 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -T clangcl -B out4 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Debug'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out6 -v --config Debug
+      cmakeArgs: --build out4 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Release'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out6 -v --config RelWithDebInfo
-  - task: CMake@1
-    displayName: 'CMake (ClangCl): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -T clangcl -B out7 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
-  - task: CMake@1
-    displayName: 'CMake (ClangCl): Build ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out7 -v
+      cmakeArgs: --build out4 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out8 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out5 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Debug'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out8 -v --config Debug
+      cmakeArgs: --build out5 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Release'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out8 -v --config RelWithDebInfo
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out9 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Build ARM64 Debug'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out9 -v --config Debug
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Build ARM64 Release'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out9 -v --config RelWithDebInfo
+      cmakeArgs: --build out5 -v --config RelWithDebInfo

--- a/build/UVAtlas-GitHub-Test-Dev17.yml
+++ b/build/UVAtlas-GitHub-Test-Dev17.yml
@@ -271,7 +271,7 @@ jobs:
         echo ##vso[task.prependpath]%VCINSTALLDIR%Tools\Llvm\x64\bin
         echo ##vso[task.prependpath]%WindowsSdkBinPath%x64
         echo ##vso[task.prependpath]%WindowsSdkVerBinPath%x64
-        echo ##vso[task.prependpath]%VCToolsInstallDir%bin\Hostx64\x64
+        echo ##vso[task.prependpath]%VCToolsInstallDir%bin\Hostx64\arm64
         echo ##vso[task.setvariable variable=EXTERNAL_INCLUDE;]%EXTERNAL_INCLUDE%
         echo ##vso[task.setvariable variable=INCLUDE;]%INCLUDE%
         echo ##vso[task.setvariable variable=LIB;]%LIB%

--- a/build/UVAtlas-GitHub-Test-Dev17.yml
+++ b/build/UVAtlas-GitHub-Test-Dev17.yml
@@ -137,8 +137,8 @@ jobs:
       configuration: Release
       msbuildArchitecture: x64
 
-- job: CMAKE_BUILD
-  displayName: 'CMake BUILD_TESTING=ON'
+- job: CMAKE_BUILD_X64
+  displayName: 'CMake for X64 BUILD_TESTING=ON'
   timeoutInMinutes: 120
   workspace:
     clean: all
@@ -192,6 +192,7 @@ jobs:
       cmakeArgs: --build out/build/x64-Debug -v
   - task: DeleteFiles@1
     inputs:
+      SourceFolder: $(Build.SourcesDirectory)/UVAtlas
       Contents: 'out'
   - task: CMake@1
     displayName: CMake (MSVC; x64-Release) Config
@@ -205,6 +206,7 @@ jobs:
       cmakeArgs: --build out/build/x64-Release -v
   - task: DeleteFiles@1
     inputs:
+      SourceFolder: $(Build.SourcesDirectory)/UVAtlas
       Contents: 'out'
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Debug) Config
@@ -218,6 +220,7 @@ jobs:
       cmakeArgs: --build out/build/x64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
+      SourceFolder: $(Build.SourcesDirectory)/UVAtlas
       Contents: 'out'
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Release) Config
@@ -229,16 +232,78 @@ jobs:
     inputs:
       cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --build out/build/x64-Release-Clang -v
-  - task: DeleteFiles@1
-    inputs:
-      Contents: 'out'
+
+- job: CMAKE_BUILD_ARM64
+  displayName: 'CMake for ARM64 BUILD_TESTING=ON'
+  timeoutInMinutes: 120
+  workspace:
+    clean: all
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    path: 's/UVAtlas'
+  - checkout: dxMeshRepo
+    displayName: Fetch DirectXMesh
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/DirectXMesh'
+  - checkout: dxTexRepo
+    displayName: Fetch DirectXTex
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/DirectXTex'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/UVAtlas/Tests'
   - task: CmdLine@2
-    displayName: Switch compiler to ARM64
+    displayName: Setup environment for CMake to use VS
     inputs:
       script: |
         call "$(VC_PATH)\Auxiliary\Build\vcvarsamd64_arm64.bat"
+        echo ##vso[task.setvariable variable=WindowsSdkVerBinPath;]%WindowsSdkVerBinPath%
+        echo ##vso[task.prependpath]%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja
+        echo ##vso[task.prependpath]%VCINSTALLDIR%Tools\Llvm\x64\bin
+        echo ##vso[task.prependpath]%WindowsSdkBinPath%x64
+        echo ##vso[task.prependpath]%WindowsSdkVerBinPath%x64
+        echo ##vso[task.prependpath]%VCToolsInstallDir%bin\Hostx64\x64
+        echo ##vso[task.setvariable variable=EXTERNAL_INCLUDE;]%EXTERNAL_INCLUDE%
+        echo ##vso[task.setvariable variable=INCLUDE;]%INCLUDE%
         echo ##vso[task.setvariable variable=LIB;]%LIB%
 
+  - task: CMake@1
+    displayName: CMake (MSVC; arm64-Debug) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --preset=arm64-Debug
+  - task: CMake@1
+    displayName: CMake (MSVC; arm64-Debug) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --build out/build/arm64-Debug -v
+  - task: DeleteFiles@1
+    inputs:
+      SourceFolder: $(Build.SourcesDirectory)/UVAtlas
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (MSVC; arm64-Release) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --preset=arm64-Release
+  - task: CMake@1
+    displayName: CMake (MSVC; arm64-Release) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --build out/build/arm64-Release -v
+  - task: DeleteFiles@1
+    inputs:
+      SourceFolder: $(Build.SourcesDirectory)/UVAtlas
+      Contents: 'out'
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Debug) Config
     inputs:
@@ -251,6 +316,7 @@ jobs:
       cmakeArgs: --build out/build/arm64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
+      SourceFolder: $(Build.SourcesDirectory)/UVAtlas
       Contents: 'out'
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Release) Config
@@ -258,9 +324,7 @@ jobs:
       cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --preset=arm64-Release-Clang
   - task: CMake@1
-    # This is disabled to avoid an ICE with clang v15.0.1
     displayName: CMake (clang/LLVM; arm64-Release) Build
-    enabled: false
     inputs:
       cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --build out/build/arm64-Release-Clang -v

--- a/build/UVAtlas-GitHub-Test-Dev17.yml
+++ b/build/UVAtlas-GitHub-Test-Dev17.yml
@@ -325,6 +325,8 @@ jobs:
       cmakeArgs: --preset=arm64-Release-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Release) Build
+    # Disabled due to linker bug in clang v18
+    enabled: false
     inputs:
       cwd: $(Build.SourcesDirectory)/UVAtlas
       cmakeArgs: --build out/build/arm64-Release-Clang -v

--- a/build/UVAtlas-GitHub-Test.yml
+++ b/build/UVAtlas-GitHub-Test.yml
@@ -47,6 +47,7 @@ name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
   vmImage: windows-2019
+  VC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC'
 
 variables:
   Codeql.Enabled: false
@@ -113,19 +114,99 @@ jobs:
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution xtuvatlas_Desktop_2019.sln arm64dbg
+
+- job: CMAKE_BUILD_X64
+  displayName: 'CMake for X64 BUILD_TESTING=ON'
+  timeoutInMinutes: 120
+  workspace:
+    clean: all
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    path: 's/UVAtlas'
+  - checkout: dxMeshRepo
+    displayName: Fetch DirectXMesh
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/DirectXMesh'
+  - checkout: dxTexRepo
+    displayName: Fetch DirectXTex
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/DirectXTex'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/UVAtlas/Tests'
+  - task: CmdLine@2
+    displayName: Setup environment for CMake to use VS
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution xtuvatlas_Desktop_2019.sln arm64rel
+      script: |
+        call "$(VC_PATH)\Auxiliary\Build\vcvars64.bat"
+        echo ##vso[task.setvariable variable=WindowsSdkVerBinPath;]%WindowsSdkVerBinPath%
+        echo ##vso[task.prependpath]%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja
+        echo ##vso[task.prependpath]%VCINSTALLDIR%Tools\Llvm\x64\bin
+        echo ##vso[task.prependpath]%WindowsSdkBinPath%x64
+        echo ##vso[task.prependpath]%WindowsSdkVerBinPath%x64
+        echo ##vso[task.prependpath]%VCToolsInstallDir%bin\Hostx64\x64
+        echo ##vso[task.setvariable variable=EXTERNAL_INCLUDE;]%EXTERNAL_INCLUDE%
+        echo ##vso[task.setvariable variable=INCLUDE;]%INCLUDE%
+        echo ##vso[task.setvariable variable=LIB;]%LIB%
+
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Debug) Config
     inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --preset=x64-Debug
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Debug) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --build out/build/x64-Debug -v
+  - task: DeleteFiles@1
+    inputs:
+      SourceFolder: $(Build.SourcesDirectory)/UVAtlas
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Release) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --preset=x64-Release
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Release) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --build out/build/x64-Release -v
+  - task: DeleteFiles@1
+    inputs:
+      SourceFolder: $(Build.SourcesDirectory)/UVAtlas
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --preset=x64-Debug-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --build out/build/x64-Debug-Clang -v
+  - task: DeleteFiles@1
+    inputs:
+      SourceFolder: $(Build.SourcesDirectory)/UVAtlas
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --preset=x64-Release-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)/UVAtlas
+      cmakeArgs: --build out/build/x64-Release-Clang -v

--- a/build/UVAtlas-GitHub-Test.yml
+++ b/build/UVAtlas-GitHub-Test.yml
@@ -47,10 +47,10 @@ name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
   vmImage: windows-2019
-  VC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC'
 
 variables:
   Codeql.Enabled: false
+  VC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC'
 
 jobs:
 - job: DESKTOP_BUILD

--- a/build/UVAtlas-GitHub.yml
+++ b/build/UVAtlas-GitHub.yml
@@ -84,20 +84,6 @@ jobs:
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln arm64dbg
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln arm64rel
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
 
 - job: DESKTOP_BUILD_SPECTRE
   displayName: 'Win32 Desktop (Spectre-mitigated)'
@@ -144,18 +130,4 @@ jobs:
       solution: UVAtlas_2019_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
       platform: x64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln arm64dbg
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln arm64rel
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: ARM64
       configuration: Release


### PR DESCRIPTION
Remove cases of building for ARM64 with VS 2019 due to changes to Windows SDK (26100).