### PR TITLE
Fix to resolve CodeQL warning

### DIFF
--- a/UVAtlas/isochart/meshpartitionchart.cpp
+++ b/UVAtlas/isochart/meshpartitionchart.cpp
@@ -27,6 +27,10 @@ HRESULT CIsochartMesh::GenerateAllSubCharts(
     {
         return S_OK;
     }
+    else if (dwMaxSubchartCount > UINT16_MAX)
+    {
+        return E_INVALIDARG;
+    }
     DeleteChildren();
 
     std::unique_ptr<std::vector<uint32_t>[]> chartFaceList(new (std::nothrow) std::vector<uint32_t>[dwMaxSubchartCount]);


### PR DESCRIPTION
Set a large upper-bound for the maximum number of subcharts to 2^16 to resolve a code quality warning from GNUC.