### PR TITLE
Code review feedback for DLL declimport/export

### DIFF
--- a/.azuredevops/policies/approvercountpolicy.yml
+++ b/.azuredevops/policies/approvercountpolicy.yml
@@ -1,0 +1,20 @@
+name: approver_count
+description: Approver count policy for mscodehub/DirectXMesh/UVAtlas repository
+resource: repository
+where: 
+configuration:
+  approverCountPolicySettings:
+    isBlocking: true
+    requireMinimumApproverCount: 1
+    creatorVoteCounts: false
+    allowDownvotes: false
+    sourcePushOptions:
+      resetOnSourcePush: false
+      requireVoteOnLastIteration: true
+      requireVoteOnEachIteration: false
+      resetRejectionsOnSourcePush: false
+    blockLastPusherVote: true
+    branchNames:
+    - refs/heads/release
+    - refs/heads/main
+    displayName: mscodehub/DirectXMesh/UVAtlas Approver Count Policy

--- a/UVAtlas/UVAtlas_2022_Win10.vcxproj
+++ b/UVAtlas/UVAtlas_2022_Win10.vcxproj
@@ -183,8 +183,8 @@
     <TargetName>UVAtlas</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
-    <OutDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
-    <IntDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
     <TargetName>UVAtlas_Spectre</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/UVAtlas/inc/UVAtlas.h
+++ b/UVAtlas/inc/UVAtlas.h
@@ -44,10 +44,18 @@
 
 #define UVATLAS_VERSION 190
 
-#ifdef UVATLAS_EXPORT
+#if defined(_WIN32) && defined(UVATLAS_EXPORT)
+#ifdef __GNUC__
+#define UVATLAS_API __attribute__ ((dllexport))
+#else
 #define UVATLAS_API __declspec(dllexport)
-#elif defined(UVATLAS_IMPORT)
+#endif
+#elif defined(_WIN32) && defined(UVATLAS_IMPORT)
+#ifdef __GNUC__
+#define UVATLAS_API __attribute__ ((dllimport))
+#else
 #define UVATLAS_API __declspec(dllimport)
+#endif
 #else
 #define UVATLAS_API
 #endif

--- a/build/UVAtlas-SDL.yml
+++ b/build/UVAtlas-SDL.yml
@@ -81,6 +81,7 @@ jobs:
       result: PoliCheck.xml
       optionsPE: 1
       optionsRulesDBPath: $(Build.SourcesDirectory)/build/rule.mdb
+      optionsUEPATH: $(Build.SourcesDirectory)/build/policheck_exc.xml
   - task: Armory@2
     displayName: Run ARMory
   - task: CmdLine@2

--- a/build/policheck_exc.xml
+++ b/build/policheck_exc.xml
@@ -1,0 +1,3 @@
+<PoliCheckExclusions>
+  <Exclusion Type="FolderPathStart">VCPKG</Exclusion>
+</PoliCheckExclusions>


### PR DESCRIPTION
CoPilot suggested a change which I disagreed with, but when I researched it a bit I realized there was a different change that would be useful to prefer `__attribute__` to `__declspec` for GNUC.

> Also includes a project minor fix and AzureDev Ops polices from the production pipelines.
