### PR TITLE
Cleanup of ADO pipeline YAML files

### DIFF
--- a/.azuredevops/pipelines/UVAtlas-GitHub-CMake-Dev17.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-CMake-Dev17.yml
@@ -36,7 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.json
     - build/*.props

--- a/.azuredevops/pipelines/UVAtlas-GitHub-CMake-Dev17.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-CMake-Dev17.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.json
     - build/*.props

--- a/.azuredevops/pipelines/UVAtlas-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-CMake.yml
@@ -36,7 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.json
     - build/*.props

--- a/.azuredevops/pipelines/UVAtlas-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-CMake.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.json
     - build/*.props

--- a/.azuredevops/pipelines/UVAtlas-GitHub-Dev17.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-Dev17.yml
@@ -42,9 +42,60 @@ variables:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
-  timeoutInMinutes: 60
+  displayName: 'Windows Desktop'
+  timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+        SpectreMitigation: false
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+        SpectreMitigation: false
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+        SpectreMitigation: false
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+        SpectreMitigation: false
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+        SpectreMitigation: false
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
+        SpectreMitigation: false
+      Release_arm64_SpectreMitigated:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+        SpectreMitigation: 'Spectre'
+      Debug_arm64_SpectreMitigated:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+        SpectreMitigation: 'Spectre'
+      Release_x64_SpectreMitigated:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+        SpectreMitigation: 'Spectre'
+      Debug_x64_SpectreMitigated:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+        SpectreMitigation: 'Spectre'
+      Release_x86_SpectreMitigated:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+        SpectreMitigation: 'Spectre'
+      Debug_x86_SpectreMitigated:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
+        SpectreMitigation: 'Spectre'
   steps:
   - checkout: self
     clean: true
@@ -60,174 +111,48 @@ jobs:
       feedRestore: $(GUID_FEED)
       includeNuGetOrg: false
   - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln 32dbg
+    displayName: Build solution UVAtlas_2022_Win10.sln
     inputs:
       solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln 32rel
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln 64dbg
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln 64rel
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln arm64dbg
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln arm64rel
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
-      msbuildArchitecture: x64
-
-- job: DESKTOP_BUILD_SPECTRE
-  displayName: 'Win32 Desktop (Spectre-mitigated)'
-  timeoutInMinutes: 60
-  cancelTimeoutInMinutes: 1
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet'
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Auth'
-  - task: NuGetCommand@2
-    displayName: NuGet restore
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      feedRestore: $(GUID_FEED)
-      includeNuGetOrg: false
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln 32dbg
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln 32rel
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln 64dbg
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln 64rel
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln arm64dbg
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln arm64rel
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: ARM64
-      configuration: Release
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=$(SpectreMitigation)
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
 
 - job: UWP_BUILD
   displayName: 'Universal Windows Platform (UWP)'
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 32dbg
+    displayName: Build solution UVAtlas_Windows10_2022.sln
     inputs:
       solution: UVAtlas_Windows10_2022.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 32rel
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 64dbg
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 64rel
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln arm64dbg
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln arm64rel
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64

--- a/.azuredevops/pipelines/UVAtlas-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-MinGW.yml
@@ -35,7 +35,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.props
     - build/*.mdb

--- a/.azuredevops/pipelines/UVAtlas-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-MinGW.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.props
     - build/*.mdb

--- a/.azuredevops/pipelines/UVAtlas-GitHub-SDK-prerelease.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-SDK-prerelease.yml
@@ -97,55 +97,7 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: NuGetCommand@2
-    displayName: NuGet restore
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      selectOrConfig: config
-      nugetConfigPath: NuGet.Config
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 32dbg
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 32rel
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 64dbg
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 64rel
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  # VS 2019 for Win32 on ARM64 is out of support.
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln arm64dbg
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln arm64rel
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/UVAtlas-build-win32.yml'
 
 - job: UWP_BUILD
   displayName: 'Universal Windows Platform (UWP)'
@@ -202,46 +154,4 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 32dbg
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 32rel
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 64dbg
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 64rel
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  # Windows on ARM 32-bit is deprecated. https://learn.microsoft.com/windows/arm/arm32-to-arm64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln arm64dbg
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln arm64rel
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/UVAtlas-build-uwp.yml'

--- a/.azuredevops/pipelines/UVAtlas-GitHub-SDK-release.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-SDK-release.yml
@@ -97,55 +97,7 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: NuGetCommand@2
-    displayName: NuGet restore
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      selectOrConfig: config
-      nugetConfigPath: NuGet.Config
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 32dbg
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 32rel
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 64dbg
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 64rel
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  # VS 2019 for Win32 on ARM64 is out of support.
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln arm64dbg
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2022_Win10.sln arm64rel
-    inputs:
-      solution: UVAtlas_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/UVAtlas-build-win32.yml'
 
 - job: UWP_BUILD
   displayName: 'Universal Windows Platform (UWP)'
@@ -202,46 +154,4 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 32dbg
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 32rel
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 64dbg
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln 64rel
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  # Windows on ARM 32-bit is deprecated. https://learn.microsoft.com/windows/arm/arm32-to-arm64
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln arm64dbg
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_Windows10_2022.sln arm64rel
-    inputs:
-      solution: UVAtlas_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/UVAtlas-build-uwp.yml'

--- a/.azuredevops/pipelines/UVAtlas-GitHub-Test-Dev17.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-Test-Dev17.yml
@@ -59,6 +59,27 @@ jobs:
   cancelTimeoutInMinutes: 1
   workspace:
     clean: all
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
@@ -83,58 +104,13 @@ jobs:
     fetchDepth: 1
     path: 's/UVAtlas/Tests'
   - task: VSBuild@1
-    displayName: Build solution xtuvatlas_Desktop_2022.sln 32dbg
+    displayName: Build solution xtuvatlas_Desktop_2022.sln
     inputs:
       solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solutionxtuvatlas_Desktop_2022.sln 32rel
-    inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution xtuvatlas_Desktop_2022.sln 64dbg
-    inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution xtuvatlas_Desktop_2022.sln 64rel
-    inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution xtuvatlas_Desktop_2022.sln arm64dbg
-    inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution xtuvatlas_Desktop_2022.sln arm64rel
-    inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2022.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
 
 - job: CMAKE_BUILD_X64

--- a/.azuredevops/pipelines/UVAtlas-GitHub-Test.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub-Test.yml
@@ -54,11 +54,26 @@ variables:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
-  timeoutInMinutes: 60
+  displayName: 'Windows Desktop'
+  timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
   workspace:
     clean: all
+  strategy:
+    maxParallel: 2
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
@@ -83,37 +98,13 @@ jobs:
     fetchDepth: 1
     path: 's/UVAtlas/Tests'
   - task: VSBuild@1
-    displayName: Build solution xtuvatlas_Desktop_2019.sln 32dbg
+    displayName: Build solution xtuvatlas_Desktop_2019.sln
     inputs:
       solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solutionxtuvatlas_Desktop_2019.sln 32rel
-    inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution xtuvatlas_Desktop_2019.sln 64dbg
-    inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution xtuvatlas_Desktop_2019.sln 64rel
-    inputs:
-      solution: UVAtlas/Tests/xtuvatlas_Desktop_2019.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
 
 - job: CMAKE_BUILD_X64
   displayName: 'CMake for X64 BUILD_TESTING=ON'

--- a/.azuredevops/pipelines/UVAtlas-GitHub.yml
+++ b/.azuredevops/pipelines/UVAtlas-GitHub.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkID=512686
 
-# Builds the library for Windows Desktop and UWP.
+# Builds the library for Windows Desktop.
 
 schedules:
 - cron: "40 5 * * *"
@@ -42,9 +42,44 @@ variables:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
-  timeoutInMinutes: 60
+  displayName: 'Windows Desktop'
+  timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 2
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+        SpectreMitigation: false
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+        SpectreMitigation: false
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+        SpectreMitigation: false
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
+        SpectreMitigation: false
+      Release_x64_SpectreMitigated:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+        SpectreMitigation: 'Spectre'
+      Debug_x64_SpectreMitigated:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+        SpectreMitigation: 'Spectre'
+      Release_x86_SpectreMitigated:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+        SpectreMitigation: 'Spectre'
+      Debug_x86_SpectreMitigated:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
+        SpectreMitigation: 'Spectre'
   steps:
   - checkout: self
     clean: true
@@ -60,77 +95,9 @@ jobs:
       feedRestore: $(GUID_FEED)
       includeNuGetOrg: false
   - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 32dbg
+    displayName: Build solution UVAtlas_2019_Win10.sln
     inputs:
       solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 32rel
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 64dbg
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 64rel
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-
-- job: DESKTOP_BUILD_SPECTRE
-  displayName: 'Win32 Desktop (Spectre-mitigated)'
-  timeoutInMinutes: 60
-  cancelTimeoutInMinutes: 1
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet'
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Auth'
-  - task: NuGetCommand@2
-    displayName: NuGet restore
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      feedRestore: $(GUID_FEED)
-      includeNuGetOrg: false
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 32dbg
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 32rel
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 64dbg
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution UVAtlas_2019_Win10.sln 64rel
-    inputs:
-      solution: UVAtlas_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x64
-      configuration: Release
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=$(SpectreMitigation)
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'

--- a/.azuredevops/templates/UVAtlas-build-uwp.yml
+++ b/.azuredevops/templates/UVAtlas-build-uwp.yml
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=512686
+
+# Template used by SDK-release and SDK-prerelease pipelines
+
+steps:
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_Windows10_2022.sln 32dbg
+  inputs:
+    solution: UVAtlas_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_Windows10_2022.sln 32rel
+  inputs:
+    solution: UVAtlas_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Release
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_Windows10_2022.sln 64dbg
+  inputs:
+    solution: UVAtlas_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_Windows10_2022.sln 64rel
+  inputs:
+    solution: UVAtlas_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Release
+# Windows on ARM 32-bit is deprecated. https://learn.microsoft.com/windows/arm/arm32-to-arm64
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_Windows10_2022.sln arm64dbg
+  inputs:
+    solution: UVAtlas_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_Windows10_2022.sln arm64rel
+  inputs:
+    solution: UVAtlas_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Release

--- a/.azuredevops/templates/UVAtlas-build-win32.yml
+++ b/.azuredevops/templates/UVAtlas-build-win32.yml
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=512686
+
+# Template used by SDK-release and SDK-prerelease pipelines
+
+steps:
+- task: NuGetCommand@2
+  displayName: NuGet restore
+  inputs:
+    solution: UVAtlas_2019_Win10.sln
+    selectOrConfig: config
+    nugetConfigPath: NuGet.Config
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_2019_Win10.sln 32dbg
+  inputs:
+    solution: UVAtlas_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_2019_Win10.sln 32rel
+  inputs:
+    solution: UVAtlas_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Release
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_2019_Win10.sln 64dbg
+  inputs:
+    solution: UVAtlas_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_2019_Win10.sln 64rel
+  inputs:
+    solution: UVAtlas_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Release
+# VS 2019 for Win32 on ARM64 is out of support.
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_2022_Win10.sln arm64dbg
+  inputs:
+    solution: UVAtlas_2022_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution UVAtlas_2022_Win10.sln arm64rel
+  inputs:
+    solution: UVAtlas_2022_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Release

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -8,12 +8,21 @@ name: 'CTest (BVTs)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.mdb
+      - build/*.props
+      - build/*.ps1
+      - build/*.xml
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.mdb
       - build/*.props

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,12 +8,21 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.mdb
+      - build/*.props
+      - build/*.ps1
+      - build/*.xml
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.mdb
       - build/*.props

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,21 @@ name: 'CMake (Windows)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.mdb
+      - build/*.props
+      - build/*.ps1
+      - build/*.xml
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.mdb
       - build/*.props

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -8,12 +8,18 @@ name: MSBuild
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -8,12 +8,21 @@ name: Microsoft C++ Code Analysis
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.mdb
+      - build/*.props
+      - build/*.ps1
+      - build/*.xml
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.mdb
       - build/*.props

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,21 @@ name: 'CTest (Windows)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.mdb
+      - build/*.props
+      - build/*.ps1
+      - build/*.xml
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.mdb
       - build/*.props

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -8,12 +8,21 @@ name: 'CMake (UWP)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.mdb
+      - build/*.props
+      - build/*.ps1
+      - build/*.xml
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.mdb
       - build/*.props

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -8,11 +8,19 @@ name: 'CMake (Windows using VCPKG)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - '.azuredevops/**'
+      - LICENSE
+      - build/*.props
+      - build/*.mdb
+      - build/*.ps1
+      - build/*.xml
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - LICENSE
       - build/*.props
       - build/*.mdb

--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -8,12 +8,21 @@ name: 'CMake (WSL)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.mdb
+      - build/*.props
+      - build/*.ps1
+      - build/*.xml
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.mdb
       - build/*.props


### PR DESCRIPTION
This PR adds the use of strategy and templates to the existing ADO pipelines.

* For the basic builds using Visual Studio MSBuild with minimal job setup, I made use of `strategy` `matrix` to simplify the pipelines for GitHub, GitHub-Dev17, GitHub-Test, and GitHub-Dev17.

* For the Windows SDK NuGet pipelines which have substantial package sizes as part of job setup, I made use of `template` for SDK-release and SDK-prerelease pipelines to share implementation.
> Also updated pipeline trigger path filters: GHA should ignore everything under ``.azuredevops``, and ADO should ignore everything under ``.github``.
