### PR TITLE
UVatlasTool updated to use CMO.h and vbo.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,9 @@ if(BUILD_TOOLS AND WIN32)
         UVAtlasTool/Mesh.cpp
         UVAtlasTool/Mesh.h
         UVAtlasTool/MeshOBJ.cpp
-        UVAtlasTool/SDKMesh.h)
+        UVAtlasTool/CMO.h
+        UVAtlasTool/SDKMesh.h
+        UVAtlasTool/vbo.h)
     target_compile_features(uvatlastool PRIVATE cxx_std_17)
     target_link_libraries(uvatlastool PRIVATE
         ${PROJECT_NAME}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ These components are designed to work without requiring any content from the leg
 
 * ``build\``
 
-  + Contains YAML files for the build pipelines along with some miscellaneous build files and scripts.
+  + Contains miscellaneous build files and scripts.
 
 ## Documentation
 

--- a/UVAtlasTool/CMO.h
+++ b/UVAtlasTool/CMO.h
@@ -1,0 +1,181 @@
+//--------------------------------------------------------------------------------------
+// File: CMO.h
+//
+// .CMO files are built by Visual Studio's MeshContentTask and an example renderer was
+// provided in the VS Direct3D Starter Kit
+// https://devblogs.microsoft.com/cppblog/developing-an-app-with-the-visual-studio-3d-starter-kit-part-1-of-3/
+// https://devblogs.microsoft.com/cppblog/developing-an-app-with-the-visual-studio-3d-starter-kit-part-2-of-3/
+// https://devblogs.microsoft.com/cppblog/developing-an-app-with-the-visual-studio-3d-starter-kit-part-3-of-3/
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248929
+// http://go.microsoft.com/fwlink/?LinkID=615561
+//--------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <DirectXMath.h>
+
+#include <cstdint>
+
+
+namespace VSD3DStarter
+{
+    // .CMO files
+
+    // UINT - Mesh count
+    // { [Mesh count]
+    //      UINT - Length of name
+    //      wchar_t[] - Name of mesh (if length > 0)
+    //      UINT - Material count
+    //      { [Material count]
+    //          UINT - Length of material name
+    //          wchar_t[] - Name of material (if length > 0)
+    //          Material structure
+    //          UINT - Length of pixel shader name
+    //          wchar_t[] - Name of pixel shader (if length > 0)
+    //          { [8]
+    //              UINT - Length of texture name
+    //              wchar_t[] - Name of texture (if length > 0)
+    //          }
+    //      }
+    //      BYTE - 1 if there is skeletal animation data present
+    //      UINT - SubMesh count
+    //      { [SubMesh count]
+    //          SubMesh structure
+    //      }
+    //      UINT - IB Count
+    //      { [IB Count]
+    //          UINT - Number of USHORTs in IB
+    //          USHORT[] - Array of indices
+    //      }
+    //      UINT - VB Count
+    //      { [VB Count]
+    //          UINT - Number of verts in VB
+    //          Vertex[] - Array of vertices
+    //      }
+    //      UINT - Skinning VB Count
+    //      { [Skinning VB Count]
+    //          UINT - Number of verts in Skinning VB
+    //          SkinningVertex[] - Array of skinning verts
+    //      }
+    //      MeshExtents structure
+    //      [If skeleton animation data is not present, file ends here]
+    //      UINT - Bone count
+    //      { [Bone count]
+    //          UINT - Length of bone name
+    //          wchar_t[] - Bone name (if length > 0)
+    //          Bone structure
+    //      }
+    //      UINT - Animation clip count
+    //      { [Animation clip count]
+    //          UINT - Length of clip name
+    //          wchar_t[] - Clip name (if length > 0)
+    //          float - Start time
+    //          float - End time
+    //          UINT - Keyframe count
+    //          { [Keyframe count]
+    //              Keyframe structure
+    //          }
+    //      }
+    // }
+
+#pragma pack(push,1)
+
+    struct Material
+    {
+        DirectX::XMFLOAT4   Ambient;
+        DirectX::XMFLOAT4   Diffuse;
+        DirectX::XMFLOAT4   Specular;
+        float               SpecularPower;
+        DirectX::XMFLOAT4   Emissive;
+        DirectX::XMFLOAT4X4 UVTransform;
+    };
+
+    constexpr uint32_t MAX_TEXTURE = 8;
+
+    struct SubMesh
+    {
+        uint32_t MaterialIndex;
+        uint32_t IndexBufferIndex;
+        uint32_t VertexBufferIndex;
+        uint32_t StartIndex;
+        uint32_t PrimCount;
+    };
+
+    constexpr uint32_t NUM_BONE_INFLUENCES = 4;
+
+    // Vertex struct for Visual Studio Shader Designer (DGSL) holding position, normal,
+    // tangent, color (RGBA), and texture mapping information
+    struct Vertex
+    {
+        DirectX::XMFLOAT3 position;
+        DirectX::XMFLOAT3 normal;
+        DirectX::XMFLOAT4 tangent;
+        uint32_t color;
+        DirectX::XMFLOAT2 textureCoordinate;
+    };
+
+    struct SkinningVertex
+    {
+        uint32_t boneIndex[NUM_BONE_INFLUENCES];
+        float boneWeight[NUM_BONE_INFLUENCES];
+    };
+
+    struct MeshExtents
+    {
+        float CenterX, CenterY, CenterZ;
+        float Radius;
+
+        float MinX, MinY, MinZ;
+        float MaxX, MaxY, MaxZ;
+    };
+
+    struct Bone
+    {
+        int32_t ParentIndex;
+        DirectX::XMFLOAT4X4 InvBindPos;
+        DirectX::XMFLOAT4X4 BindPos;
+        DirectX::XMFLOAT4X4 LocalTransform;
+    };
+
+    struct Clip
+    {
+        float StartTime;
+        float EndTime;
+        uint32_t keys;
+    };
+
+    struct Keyframe
+    {
+        uint32_t BoneIndex;
+        float Time;
+        DirectX::XMFLOAT4X4 Transform;
+    };
+
+#pragma pack(pop)
+
+    const Material s_defMaterial =
+    {
+        { 0.2f, 0.2f, 0.2f, 1.f },
+        { 0.8f, 0.8f, 0.8f, 1.f },
+        { 0.0f, 0.0f, 0.0f, 1.f },
+        1.f,
+        { 0.0f, 0.0f, 0.0f, 1.0f },
+        { 1.f, 0.f, 0.f, 0.f,
+          0.f, 1.f, 0.f, 0.f,
+          0.f, 0.f, 1.f, 0.f,
+          0.f, 0.f, 0.f, 1.f },
+    };
+} // namespace
+
+static_assert(sizeof(VSD3DStarter::Material) == 132, "CMO Mesh structure size incorrect");
+static_assert(sizeof(VSD3DStarter::SubMesh) == 20, "CMO Mesh structure size incorrect");
+static_assert(sizeof(VSD3DStarter::Vertex) == 52, "CMO Mesh structure size incorrect");
+static_assert(sizeof(VSD3DStarter::SkinningVertex) == 32, "CMO Mesh structure size incorrect");
+static_assert(sizeof(VSD3DStarter::MeshExtents) == 40, "CMO Mesh structure size incorrect");
+static_assert(sizeof(VSD3DStarter::Bone) == 196, "CMO Mesh structure size incorrect");
+static_assert(sizeof(VSD3DStarter::Clip) == 12, "CMO Mesh structure size incorrect");
+static_assert(sizeof(VSD3DStarter::Keyframe) == 72, "CMO Mesh structure size incorrect");

--- a/UVAtlasTool/Mesh.cpp
+++ b/UVAtlasTool/Mesh.cpp
@@ -34,7 +34,9 @@
 #include <new>
 #include <utility>
 
+#include "CMO.h"
 #include "SDKMesh.h"
+#include "vbo.h"
 
 #include <DirectXPackedVector.h>
 #include <DirectXCollision.h>
@@ -1228,31 +1230,6 @@ HRESULT Mesh::GetVertexBuffer(const DirectX::VBWriter& writer) const noexcept
 // VBO
 //======================================================================================
 
-namespace VBO
-{
-
-#pragma pack(push,1)
-
-    struct header_t
-    {
-        uint32_t numVertices;
-        uint32_t numIndices;
-    };
-
-    struct vertex_t
-    {
-        DirectX::XMFLOAT3 position;
-        DirectX::XMFLOAT3 normal;
-        DirectX::XMFLOAT2 textureCoordinate;
-    };
-
-#pragma pack(pop)
-
-    static_assert(sizeof(header_t) == 8, "VBO header size mismatch");
-    static_assert(sizeof(vertex_t) == 32, "VBO vertex size mismatch");
-} // namespace
-
-
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT Mesh::ExportToVBO(const wchar_t* szFileName) const noexcept
@@ -1482,158 +1459,6 @@ HRESULT Mesh::CreateFromVBO(const wchar_t* szFileName, std::unique_ptr<Mesh>& re
 //======================================================================================
 
 //--------------------------------------------------------------------------------------
-// .CMO files are built by Visual Studio 2012 and an example renderer is provided
-// in the VS Direct3D Starter Kit
-// http://code.msdn.microsoft.com/Visual-Studio-3D-Starter-455a15f1
-//--------------------------------------------------------------------------------------
-
-namespace VSD3DStarter
-{
-    // .CMO files
-
-    // UINT - Mesh count
-    // { [Mesh count]
-    //      UINT - Length of name
-    //      wchar_t[] - Name of mesh (if length > 0)
-    //      UINT - Material count
-    //      { [Material count]
-    //          UINT - Length of material name
-    //          wchar_t[] - Name of material (if length > 0)
-    //          Material structure
-    //          UINT - Length of pixel shader name
-    //          wchar_t[] - Name of pixel shader (if length > 0)
-    //          { [8]
-    //              UINT - Length of texture name
-    //              wchar_t[] - Name of texture (if length > 0)
-    //          }
-    //      }
-    //      BYTE - 1 if there is skeletal animation data present
-    //      UINT - SubMesh count
-    //      { [SubMesh count]
-    //          SubMesh structure
-    //      }
-    //      UINT - IB Count
-    //      { [IB Count]
-    //          UINT - Number of USHORTs in IB
-    //          USHORT[] - Array of indices
-    //      }
-    //      UINT - VB Count
-    //      { [VB Count]
-    //          UINT - Number of verts in VB
-    //          Vertex[] - Array of vertices
-    //      }
-    //      UINT - Skinning VB Count
-    //      { [Skinning VB Count]
-    //          UINT - Number of verts in Skinning VB
-    //          SkinningVertex[] - Array of skinning verts
-    //      }
-    //      MeshExtents structure
-    //      [If skeleton animation data is not present, file ends here]
-    //      UINT - Bone count
-    //      { [Bone count]
-    //          UINT - Length of bone name
-    //          wchar_t[] - Bone name (if length > 0)
-    //          Bone structure
-    //      }
-    //      UINT - Animation clip count
-    //      { [Animation clip count]
-    //          UINT - Length of clip name
-    //          wchar_t[] - Clip name (if length > 0)
-    //          float - Start time
-    //          float - End time
-    //          UINT - Keyframe count
-    //          { [Keyframe count]
-    //              Keyframe structure
-    //          }
-    //      }
-    // }
-
-#pragma pack(push,1)
-
-    struct Material
-    {
-        DirectX::XMFLOAT4   Ambient;
-        DirectX::XMFLOAT4   Diffuse;
-        DirectX::XMFLOAT4   Specular;
-        float               SpecularPower;
-        DirectX::XMFLOAT4   Emissive;
-        DirectX::XMFLOAT4X4 UVTransform;
-    };
-
-    constexpr uint32_t MAX_TEXTURE = 8;
-
-    struct SubMesh
-    {
-        UINT MaterialIndex;
-        UINT IndexBufferIndex;
-        UINT VertexBufferIndex;
-        UINT StartIndex;
-        UINT PrimCount;
-    };
-
-    constexpr uint32_t NUM_BONE_INFLUENCES = 4;
-
-    struct Vertex
-    {
-        DirectX::XMFLOAT3 Position;
-        DirectX::XMFLOAT3 Normal;
-        DirectX::XMFLOAT4 Tangent;
-        UINT color;
-        DirectX::XMFLOAT2 TextureCoordinates;
-    };
-
-    struct SkinningVertex
-    {
-        UINT boneIndex[NUM_BONE_INFLUENCES];
-        float boneWeight[NUM_BONE_INFLUENCES];
-    };
-
-    struct MeshExtents
-    {
-        float CenterX, CenterY, CenterZ;
-        float Radius;
-
-        float MinX, MinY, MinZ;
-        float MaxX, MaxY, MaxZ;
-    };
-
-    struct Bone
-    {
-        INT ParentIndex;
-        DirectX::XMFLOAT4X4 InvBindPos;
-        DirectX::XMFLOAT4X4 BindPos;
-        DirectX::XMFLOAT4X4 LocalTransform;
-    };
-
-    struct Clip
-    {
-        float StartTime;
-        float EndTime;
-        UINT  keys;
-    };
-
-    struct Keyframe
-    {
-        UINT BoneIndex;
-        float Time;
-        DirectX::XMFLOAT4X4 Transform;
-    };
-
-#pragma pack(pop)
-
-} // namespace
-
-static_assert(sizeof(VSD3DStarter::Material) == 132, "CMO Mesh structure size incorrect");
-static_assert(sizeof(VSD3DStarter::SubMesh) == 20, "CMO Mesh structure size incorrect");
-static_assert(sizeof(VSD3DStarter::Vertex) == 52, "CMO Mesh structure size incorrect");
-static_assert(sizeof(VSD3DStarter::SkinningVertex) == 32, "CMO Mesh structure size incorrect");
-static_assert(sizeof(VSD3DStarter::MeshExtents) == 40, "CMO Mesh structure size incorrect");
-static_assert(sizeof(VSD3DStarter::Bone) == 196, "CMO Mesh structure size incorrect");
-static_assert(sizeof(VSD3DStarter::Clip) == 12, "CMO Mesh structure size incorrect");
-static_assert(sizeof(VSD3DStarter::Keyframe) == 72, "CMO Mesh structure size incorrect");
-
-
-//--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT Mesh::ExportToCMO(const wchar_t* szFileName, size_t nMaterials, const Material* materials) const noexcept
 {
@@ -1674,10 +1499,10 @@ HRESULT Mesh::ExportToCMO(const wchar_t* szFileName, size_t nMaterials, const Ma
     auto vptr = vb.get();
     for (size_t j = 0; j < mnVerts; ++j, ++vptr)
     {
-        vptr->Position = mPositions[j];
-        vptr->Normal = mNormals[j];
-        vptr->Tangent = mTangents[j];
-        vptr->TextureCoordinates = mTexCoords[j];
+        vptr->position = mPositions[j];
+        vptr->normal = mNormals[j];
+        vptr->tangent = mTangents[j];
+        vptr->textureCoordinate = mTexCoords[j];
 
         if (mColors)
         {

--- a/UVAtlasTool/Mesh.cpp
+++ b/UVAtlasTool/Mesh.cpp
@@ -1575,7 +1575,7 @@ HRESULT Mesh::ExportToCMO(const wchar_t* szFileName, size_t nMaterials, const Ma
     }
 
     // Write materials
-    static const Mesh::Material s_defMaterial = { L"default", false, 1.f, 1.f,
+    static const Mesh::Material s_defCMOMaterial = { L"default", false, 1.f, 1.f,
         XMFLOAT3(0.2f, 0.2f, 0.2f), XMFLOAT3(0.8f, 0.8f, 0.8f),
         XMFLOAT3(0.f, 0.f, 0.f), XMFLOAT3(0.f, 0.f, 0.f), L"" };
 
@@ -1587,7 +1587,7 @@ HRESULT Mesh::ExportToCMO(const wchar_t* szFileName, size_t nMaterials, const Ma
     else
     {
         nMaterials = 1;
-        materials = &s_defMaterial;
+        materials = &s_defCMOMaterial;
     }
 
     hr = write_file(hFile.get(), materialCount);

--- a/UVAtlasTool/SDKMesh.h
+++ b/UVAtlasTool/SDKMesh.h
@@ -56,9 +56,9 @@ namespace DXUT
     enum D3DDECLUSAGE
     {
         D3DDECLUSAGE_POSITION = 0,
-        D3DDECLUSAGE_BLENDWEIGHT =1,
-        D3DDECLUSAGE_BLENDINDICES =2,
-        D3DDECLUSAGE_NORMAL =3,
+        D3DDECLUSAGE_BLENDWEIGHT = 1,
+        D3DDECLUSAGE_BLENDINDICES = 2,
+        D3DDECLUSAGE_NORMAL = 3,
         D3DDECLUSAGE_TEXCOORD = 5,
         D3DDECLUSAGE_TANGENT = 6,
         D3DDECLUSAGE_BINORMAL = 7,
@@ -67,29 +67,51 @@ namespace DXUT
 
     enum D3DDECLTYPE
     {
-        D3DDECLTYPE_FLOAT1    =  0,  // 1D float expanded to (value, 0., 0., 1.)
-        D3DDECLTYPE_FLOAT2    =  1,  // 2D float expanded to (value, value, 0., 1.)
-        D3DDECLTYPE_FLOAT3    =  2,  // 3D float expanded to (value, value, value, 1.)
-        D3DDECLTYPE_FLOAT4    =  3,  // 4D float
-        D3DDECLTYPE_D3DCOLOR  =  4,  // 4D packed unsigned bytes mapped to 0. to 1. range
-                                     // Input is in D3DCOLOR format (ARGB) expanded to (R, G, B, A)
-        D3DDECLTYPE_UBYTE4    =  5,  // 4D unsigned uint8_t
-        D3DDECLTYPE_UBYTE4N   =  8,  // Each of 4 bytes is normalized by dividing to 255.0
-        D3DDECLTYPE_SHORT4N   = 10,  // 4D signed short normalized (v[0]/32767.0,v[1]/32767.0,v[2]/32767.0,v[3]/32767.0)
-        D3DDECLTYPE_DEC3N     = 14,  // 3D signed normalized (v[0]/511.0, v[1]/511.0, v[2]/511.0, 1.)
-                                     // Note: There is no equivalent to D3DDECLTYPE_DEC3N (14) as a DXGI_FORMAT
-        D3DDECLTYPE_FLOAT16_2 = 15,  // Two 16-bit floating point values, expanded to (value, value, 0, 1)
-        D3DDECLTYPE_FLOAT16_4 = 16,  // Four 16-bit floating point values
+        D3DDECLTYPE_FLOAT1 = 0,
+        // 1D float expanded to (value, 0., 0., 1.)
 
-        D3DDECLTYPE_UNUSED    = 17,  // When the type field in a decl is unused.
+        D3DDECLTYPE_FLOAT2 = 1,
+        // 2D float expanded to (value, value, 0., 1.)
+
+        D3DDECLTYPE_FLOAT3 = 2,
+        // 3D float expanded to (value, value, value, 1.)
+
+        D3DDECLTYPE_FLOAT4 = 3,
+        // 4D float
+
+        D3DDECLTYPE_D3DCOLOR = 4,
+        // 4D packed unsigned bytes mapped to 0. to 1. range
+        // Input is in D3DCOLOR format (ARGB) expanded to (R, G, B, A)
+
+        D3DDECLTYPE_UBYTE4 = 5,
+        // 4D unsigned uint8_t
+
+        D3DDECLTYPE_UBYTE4N = 8,
+        // Each of 4 bytes is normalized by dividing to 255.0
+
+        D3DDECLTYPE_SHORT4N = 10,
+        // 4D signed short normalized (v[0]/32767.0,v[1]/32767.0,v[2]/32767.0,v[3]/32767.0)
+
+        D3DDECLTYPE_DEC3N = 14,
+        // 3D signed normalized (v[0]/511.0, v[1]/511.0, v[2]/511.0, 1.)
+        // Note: There is no equivalent to D3DDECLTYPE_DEC3N (14) as a DXGI_FORMAT
+
+        D3DDECLTYPE_FLOAT16_2 = 15,
+        // Two 16-bit floating point values, expanded to (value, value, 0, 1)
+
+        D3DDECLTYPE_FLOAT16_4 = 16,
+        // Four 16-bit floating point values
+
+        D3DDECLTYPE_UNUSED = 17,
+        // When the type field in a decl is unused.
 
         // These are extensions for DXGI-based versions of Direct3D
         D3DDECLTYPE_DXGI_R10G10B10A2_UNORM = 32 + DXGI_FORMAT_R10G10B10A2_UNORM,
-        D3DDECLTYPE_DXGI_R11G11B10_FLOAT   = 32 + DXGI_FORMAT_R11G11B10_FLOAT,
-        D3DDECLTYPE_DXGI_R8G8B8A8_SNORM    = 32 + DXGI_FORMAT_R8G8B8A8_SNORM,
+        D3DDECLTYPE_DXGI_R11G11B10_FLOAT = 32 + DXGI_FORMAT_R11G11B10_FLOAT,
+        D3DDECLTYPE_DXGI_R8G8B8A8_SNORM = 32 + DXGI_FORMAT_R8G8B8A8_SNORM,
     };
 
-    #pragma pack(push,4)
+#pragma pack(push,4)
 
     struct D3DVERTEXELEMENT9
     {
@@ -101,11 +123,11 @@ namespace DXUT
         uint8_t  UsageIndex; // Semantic index
     };
 
-    #pragma pack(pop)
+#pragma pack(pop)
 
-    //--------------------------------------------------------------------------------------
-    // Hard Defines for the various structures
-    //--------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------
+// Hard Defines for the various structures
+//--------------------------------------------------------------------------------------
     constexpr uint32_t SDKMESH_FILE_VERSION = 101;
     constexpr uint32_t SDKMESH_FILE_VERSION_V2 = 200;
 
@@ -118,7 +140,7 @@ namespace DXUT
     constexpr uint32_t MAX_TEXTURE_NAME = MAX_PATH;
     constexpr uint32_t MAX_MATERIAL_PATH = MAX_PATH;
     constexpr uint32_t INVALID_FRAME = uint32_t(-1);
-    constexpr uint32_t INVALID_MESH =  uint32_t(-1);
+    constexpr uint32_t INVALID_MESH = uint32_t(-1);
     constexpr uint32_t INVALID_MATERIAL = uint32_t(-1);
     constexpr uint32_t INVALID_SUBSET = uint32_t(-1);
     constexpr uint32_t INVALID_ANIMATION_DATA = uint32_t(-1);
@@ -156,7 +178,7 @@ namespace DXUT
     //--------------------------------------------------------------------------------------
     // Structures.
     //--------------------------------------------------------------------------------------
-    #pragma pack(push,8)
+#pragma pack(push,8)
 
     struct SDKMESH_HEADER
     {
@@ -320,19 +342,19 @@ namespace DXUT
         uint64_t DataOffset;
     };
 
-    #pragma pack(pop)
+#pragma pack(pop)
 
 } // namespace
 
-static_assert( sizeof(DXUT::D3DVERTEXELEMENT9) == 8, "Direct3D9 Decl structure size incorrect" );
-static_assert( sizeof(DXUT::SDKMESH_HEADER)== 104, "SDK Mesh structure size incorrect" );
-static_assert( sizeof(DXUT::SDKMESH_VERTEX_BUFFER_HEADER) == 288, "SDK Mesh structure size incorrect" );
-static_assert( sizeof(DXUT::SDKMESH_INDEX_BUFFER_HEADER) == 32, "SDK Mesh structure size incorrect" );
-static_assert( sizeof(DXUT::SDKMESH_MESH) == 224, "SDK Mesh structure size incorrect" );
-static_assert( sizeof(DXUT::SDKMESH_SUBSET) == 144, "SDK Mesh structure size incorrect" );
-static_assert( sizeof(DXUT::SDKMESH_FRAME) == 184, "SDK Mesh structure size incorrect" );
-static_assert( sizeof(DXUT::SDKMESH_MATERIAL) == 1256, "SDK Mesh structure size incorrect" );
-static_assert( sizeof(DXUT::SDKMESH_MATERIAL_V2) == sizeof(DXUT::SDKMESH_MATERIAL), "SDK Mesh structure size incorrect" );
-static_assert( sizeof(DXUT::SDKANIMATION_FILE_HEADER) == 40, "SDK Mesh structure size incorrect" );
-static_assert( sizeof(DXUT::SDKANIMATION_DATA) == 40, "SDK Mesh structure size incorrect" );
-static_assert( sizeof(DXUT::SDKANIMATION_FRAME_DATA) == 112, "SDK Mesh structure size incorrect" );
+static_assert(sizeof(DXUT::D3DVERTEXELEMENT9) == 8, "Direct3D9 Decl structure size incorrect");
+static_assert(sizeof(DXUT::SDKMESH_HEADER)== 104, "SDK Mesh structure size incorrect");
+static_assert(sizeof(DXUT::SDKMESH_VERTEX_BUFFER_HEADER) == 288, "SDK Mesh structure size incorrect");
+static_assert(sizeof(DXUT::SDKMESH_INDEX_BUFFER_HEADER) == 32, "SDK Mesh structure size incorrect");
+static_assert(sizeof(DXUT::SDKMESH_MESH) == 224, "SDK Mesh structure size incorrect");
+static_assert(sizeof(DXUT::SDKMESH_SUBSET) == 144, "SDK Mesh structure size incorrect");
+static_assert(sizeof(DXUT::SDKMESH_FRAME) == 184, "SDK Mesh structure size incorrect");
+static_assert(sizeof(DXUT::SDKMESH_MATERIAL) == 1256, "SDK Mesh structure size incorrect");
+static_assert(sizeof(DXUT::SDKMESH_MATERIAL_V2) == sizeof(DXUT::SDKMESH_MATERIAL), "SDK Mesh structure size incorrect");
+static_assert(sizeof(DXUT::SDKANIMATION_FILE_HEADER) == 40, "SDK Mesh structure size incorrect");
+static_assert(sizeof(DXUT::SDKANIMATION_DATA) == 40, "SDK Mesh structure size incorrect");
+static_assert(sizeof(DXUT::SDKANIMATION_FRAME_DATA) == 112, "SDK Mesh structure size incorrect");

--- a/UVAtlasTool/UVAtlasTool_2019.vcxproj
+++ b/UVAtlasTool/UVAtlasTool_2019.vcxproj
@@ -301,8 +301,10 @@
     <ClCompile Include="UVAtlas.cpp" />
     <ClCompile Include="Mesh.cpp" />
     <ClInclude Include="CmdLineHelpers.h" />
+    <ClInclude Include="CMO.h" />
     <CLInclude Include="Mesh.h" />
     <ClInclude Include="SDKMesh.h" />
+    <ClInclude Include="vbo.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="UVAtlas.rc" />

--- a/UVAtlasTool/UVAtlasTool_2019.vcxproj.filters
+++ b/UVAtlasTool/UVAtlasTool_2019.vcxproj.filters
@@ -8,6 +8,9 @@
     <Filter Include="Wavefront OBJ">
       <UniqueIdentifier>{c8076e0b-beef-46c6-8c4b-128ccc82a987}</UniqueIdentifier>
     </Filter>
+    <Filter Include="RuntimeFormats">
+      <UniqueIdentifier>{f7f953f1-2caf-49d0-be5e-e9733824fc0c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="UVAtlas.cpp" />
@@ -18,8 +21,16 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="SDKMesh.h" />
     <ClInclude Include="CmdLineHelpers.h" />
+    <ClInclude Include="SDKMesh.h">
+      <Filter>RuntimeFormats</Filter>
+    </ClInclude>
+    <ClInclude Include="CMO.h">
+      <Filter>RuntimeFormats</Filter>
+    </ClInclude>
+    <ClInclude Include="vbo.h">
+      <Filter>RuntimeFormats</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="UVAtlas.rc">

--- a/UVAtlasTool/UVAtlasTool_2022.vcxproj
+++ b/UVAtlasTool/UVAtlasTool_2022.vcxproj
@@ -301,8 +301,10 @@
     <ClCompile Include="UVAtlas.cpp" />
     <ClCompile Include="Mesh.cpp" />
     <ClInclude Include="CmdLineHelpers.h" />
+    <ClInclude Include="CMO.h" />
     <CLInclude Include="Mesh.h" />
     <ClInclude Include="SDKMesh.h" />
+    <ClInclude Include="vbo.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="UVAtlas.rc" />

--- a/UVAtlasTool/UVAtlasTool_2022.vcxproj.filters
+++ b/UVAtlasTool/UVAtlasTool_2022.vcxproj.filters
@@ -8,6 +8,9 @@
     <Filter Include="Wavefront OBJ">
       <UniqueIdentifier>{c8076e0b-beef-46c6-8c4b-128ccc82a987}</UniqueIdentifier>
     </Filter>
+    <Filter Include="RuntimeFormats">
+      <UniqueIdentifier>{fb272b27-7148-4457-9632-c8fcc1a4d632}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="UVAtlas.cpp" />
@@ -18,8 +21,16 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="SDKMesh.h" />
     <ClInclude Include="CmdLineHelpers.h" />
+    <ClInclude Include="SDKMesh.h">
+      <Filter>RuntimeFormats</Filter>
+    </ClInclude>
+    <ClInclude Include="CMO.h">
+      <Filter>RuntimeFormats</Filter>
+    </ClInclude>
+    <ClInclude Include="vbo.h">
+      <Filter>RuntimeFormats</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="UVAtlas.rc">

--- a/UVAtlasTool/vbo.h
+++ b/UVAtlasTool/vbo.h
@@ -1,0 +1,43 @@
+//--------------------------------------------------------------------------------------
+// File: vbo.h
+//
+// The VBO file format was introduced in the Windows 8.0 ResourceLoading sample. It's
+// a simple binary file containing a 16-bit index buffer and a fixed-format vertex buffer.
+//
+// The meshconvert sample tool for DirectXMesh can produce this file type
+// http://go.microsoft.com/fwlink/?LinkID=324981
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248929
+// http://go.microsoft.com/fwlink/?LinkID=615561
+//--------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+
+namespace VBO
+{
+#pragma pack(push,1)
+
+    struct header_t
+    {
+        uint32_t numVertices;
+        uint32_t numIndices;
+    };
+
+    struct vertex_t
+    {
+        DirectX::XMFLOAT3 position;
+        DirectX::XMFLOAT3 normal;
+        DirectX::XMFLOAT2 textureCoordinate;
+    };
+
+#pragma pack(pop)
+
+} // namespace
+
+static_assert(sizeof(VBO::header_t) == 8, "VBO header size mismatch");
+static_assert(sizeof(VBO::vertex_t) == 32, "VBO vertex size mismatch");


### PR DESCRIPTION
In *DirectX Tool Kit* there is a CMO.h, VBO.h, and SDKMESH.h header for the various Microsoft runtime mesh formats. This has uvatlastool using the CMO.h and VBO.h files that match the toolkit versions.
