### PR TITLE
Upgrade to CMake 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.21)
 
 set(UVATLAS_VERSION 1.9.1)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": 2,
+  "version": 3,
   "configurePresets": [
     {
       "name": "base",
@@ -8,7 +8,7 @@
       "generator": "Ninja",
       "hidden": true,
       "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "cacheVariables": { "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}" }
+      "installDir": "${sourceDir}/out/install/${presetName}"
     },
 
     {
@@ -91,12 +91,7 @@
     },
     {
       "name": "VCPKG",
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": {
-          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-          "type": "FILEPATH"
-        }
-      },
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
       "hidden": true
     },
     {

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/UVAtlas/secur
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/UVAtlas/blob/main/CHANGELOG.md).
 
+* The CMake projects require 3.21 or later. VS 2019 users will need to install a standalone version of CMake 3.21 or later and add it to their PATH.
+
 * Starting with the March 2025 release, Windows 7 and Windows 8.0 support has been retired.
 
 * Starting with the December 2020 release, this library makes use of typed enum bitmask flags per the recommendation of the _C++ Standard_ section _17.5.2.1.3 Bitmask types_. This is consistent with Direct3D 12's use of the ``DEFINE_ENUM_FLAG_OPERATORS`` macro. This may have _breaking change_ impacts to client code:


### PR DESCRIPTION
CMake 3.21 comes with VS 2022.

> VS 2019 users will need to install a standalone version of a CMake newer than the 3.20 that comes with it.